### PR TITLE
Use single SVG app icon and update manifest

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,9 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/svg+xml" href="/icon.svg" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no" />

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-label="Checklist Icon">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#667eea" />
+      <stop offset="100%" stop-color="#764ba2" />
+    </linearGradient>
+  </defs>
+  <rect x="32" y="32" width="448" height="448" rx="96" fill="url(#bg)" />
+  <rect x="124" y="124" width="264" height="264" rx="44" fill="#ffffff" opacity="0.95" />
+  <g fill="none" stroke="#22c55e" stroke-width="24" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M170 194 l24 24 l40 -44" />
+    <path d="M170 258 l24 24 l40 -44" />
+    <path d="M170 322 l24 24 l40 -44" />
+  </g>
+  <g fill="none" stroke="#5b7cfa" stroke-width="18" stroke-linecap="round">
+    <line x1="252" y1="194" x2="336" y2="194" />
+    <line x1="252" y1="258" x2="336" y2="258" />
+    <line x1="252" y1="322" x2="336" y2="322" />
+  </g>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -10,16 +10,10 @@
   "orientation": "portrait",
   "icons": [
     {
-      "src": "/check-list/icon-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable any"
-    },
-    {
-      "src": "/check-list/icon-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable any"
+      "src": "/check-list/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Replace multiple raster favicon files with a single scalable SVG icon to simplify asset management and improve sharpness across resolutions.

### Description
- Add `public/icon.svg` containing the checklist SVG artwork used as the app icon.
- Replace the PNG/favicon entries in `index.html` with a single `link rel="icon" type="image/svg+xml" href="/icon.svg"`.
- Update `public/manifest.webmanifest` to reference `"/check-list/icon.svg"` with `"sizes": "any"` and `"type": "image/svg+xml"`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a000536071c832c884c54d36acb6a14)