### PR TITLE
fix: iOS standalone mode でフッターの初期高さが過大になる問題を修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import NavigationBar, { type NavItem } from './components/NavigationBar.vue'
 import GenericChecklist from './components/GenericChecklist.vue'
 
@@ -102,9 +102,32 @@ watch(checklists, () => {
   saveChecklists()
 }, { deep: true })
 
+// フッター要素の ref と ResizeObserver
+const bottomBarEl = ref<HTMLElement | null>(null)
+let bottomBarObserver: ResizeObserver | null = null
+
 // コンポーネントマウント時にチェックリストを読み込む
 onMounted(() => {
   loadChecklists()
+
+  // フッターの実際の高さを CSS 変数に反映し、view-container の bottom を動的に設定する
+  if (bottomBarEl.value) {
+    const applyHeight = () => {
+      if (bottomBarEl.value) {
+        document.documentElement.style.setProperty(
+          '--bottom-bar-height',
+          `${bottomBarEl.value.offsetHeight}px`
+        )
+      }
+    }
+    applyHeight()
+    bottomBarObserver = new ResizeObserver(applyHeight)
+    bottomBarObserver.observe(bottomBarEl.value)
+  }
+})
+
+onBeforeUnmount(() => {
+  bottomBarObserver?.disconnect()
 })
 
 // ナビゲーション項目を計算
@@ -406,7 +429,7 @@ const handleTouchEnd = () => {
         </div>
       </div>
     </div>
-    <div class="bottom-bar">
+    <div class="bottom-bar" ref="bottomBarEl">
       <div class="progress">
         {{ stats.completedCount }} / {{ stats.totalCount }} 完了
       </div>
@@ -444,7 +467,7 @@ const handleTouchEnd = () => {
 .view-container {
   position: absolute;
   top: var(--nav-bar-height); /* ナビゲーションバーの直下から開始 */
-  bottom: 100px;
+  bottom: var(--bottom-bar-height, 100px);
   left: 0;
   right: 0;
   display: flex;
@@ -492,7 +515,7 @@ const handleTouchEnd = () => {
   right: 0;
   background: white;
   box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
-  padding: 15px 20px calc(15px + env(safe-area-inset-bottom));
+  padding: 15px 20px calc(15px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom)));
   z-index: 1001; /* ナビゲーションバーよりも上に配置 */
 }
 
@@ -570,7 +593,7 @@ const handleTouchEnd = () => {
 
 @media (max-width: 600px) {
   .bottom-bar {
-    padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
+    padding: 12px 16px calc(12px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom)));
   }
 
   .edit-button,

--- a/src/App.vue
+++ b/src/App.vue
@@ -515,7 +515,7 @@ const handleTouchEnd = () => {
   right: 0;
   background: white;
   box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
-  padding: 15px 20px calc(15px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom)));
+  padding: 15px 20px calc(15px + var(--safe-area-inset-bottom, min(34px, env(safe-area-inset-bottom))));
   z-index: 1001; /* ナビゲーションバーよりも上に配置 */
 }
 
@@ -593,7 +593,7 @@ const handleTouchEnd = () => {
 
 @media (max-width: 600px) {
   .bottom-bar {
-    padding: 12px 16px calc(12px + var(--safe-area-inset-bottom, env(safe-area-inset-bottom)));
+    padding: 12px 16px calc(12px + var(--safe-area-inset-bottom, min(34px, env(safe-area-inset-bottom))));
   }
 
   .edit-button,

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,10 +9,11 @@ const updateSafeAreaBottom = () => {
   probe.style.cssText =
     'position:fixed;bottom:0;width:0;height:env(safe-area-inset-bottom);pointer-events:none;visibility:hidden;z-index:-1'
   document.body.appendChild(probe)
-  document.documentElement.style.setProperty(
-    '--safe-area-inset-bottom',
-    `${probe.offsetHeight}px`
-  )
+  // iOS PWA 起動直後に Dynamic Island デバイスで env(safe-area-inset-bottom) が
+  // 誤って大きい値（safe-area-inset-top の値など）を返すバグへの対処。
+  // ホームインジケーターの高さは全 iPhone で 34px のため上限を設ける。
+  const inset = Math.min(probe.offsetHeight, 34)
+  document.documentElement.style.setProperty('--safe-area-inset-bottom', `${inset}px`)
   document.body.removeChild(probe)
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,26 @@ import { createApp } from 'vue'
 import './index.css'
 import App from './App.vue'
 
+// iOS standalone mode では env(safe-area-inset-bottom) の初期値が
+// 不正確になる場合がある。probe 要素で実測し CSS 変数に反映する。
+const updateSafeAreaBottom = () => {
+  const probe = document.createElement('div')
+  probe.style.cssText =
+    'position:fixed;bottom:0;width:0;height:env(safe-area-inset-bottom);pointer-events:none;visibility:hidden;z-index:-1'
+  document.body.appendChild(probe)
+  document.documentElement.style.setProperty(
+    '--safe-area-inset-bottom',
+    `${probe.offsetHeight}px`
+  )
+  document.body.removeChild(probe)
+}
+
+updateSafeAreaBottom()
+// 初期レイアウト後に再計算（iOS が 2 フレーム以内に値を確定させるケースに対応）
+requestAnimationFrame(() => requestAnimationFrame(updateSafeAreaBottom))
+// visualViewport のリサイズ時（スクロールや画面回転など）にも再計算
+window.visualViewport?.addEventListener('resize', updateSafeAreaBottom)
+
 createApp(App).mount('#app')
 
 // 画面を縦向きに固定


### PR DESCRIPTION
## Summary

- iOS ホーム画面追加後の起動直後に `env(safe-area-inset-bottom)` が不正確な値を返し、フッターが過大な高さになる問題を修正
- `main.ts` で probe 要素を使い実測した値を `--safe-area-inset-bottom` CSS 変数に設定し、`visualViewport.resize` イベントで再計算することでスクロール操作なしに正しい高さを維持
- `ResizeObserver` でフッターの実際の高さを `--bottom-bar-height` CSS 変数に反映し、`.view-container` の `bottom` がフッター高さに常に追従するよう修正

## 変更ファイル

- `src/main.ts`: `updateSafeAreaBottom` 関数を追加。即時実行 + 2 フレーム後の再計算 + `visualViewport.resize` リスナーで `--safe-area-inset-bottom` を常に正確な値に保つ
- `src/App.vue`:
  - フッター要素に `ref="bottomBarEl"` を追加
  - `ResizeObserver` でフッター高さを `--bottom-bar-height` CSS 変数に反映
  - `.view-container` の `bottom: 100px` → `var(--bottom-bar-height, 100px)` に変更
  - フッターの `padding-bottom` で `env(safe-area-inset-bottom)` → `var(--safe-area-inset-bottom, env(safe-area-inset-bottom))` に変更

## Test plan

- [ ] iOS でホーム画面に追加し、アプリを起動してフッターの高さが正常であることを確認
- [ ] スクロールせずに初期表示でフッターが過大な高さにならないことを確認
- [ ] iPhone X 以降（ホームインジケーターあり）で safe-area が正しく適用されることを確認
- [ ] 通常の Safari ブラウザでも動作に問題がないことを確認

https://claude.ai/code/session_01R96oPbvZ9okg4zJ8cxWZCg

---
_Generated by [Claude Code](https://claude.ai/code/session_01R96oPbvZ9okg4zJ8cxWZCg)_