### PR TITLE
fix: iOS PWA ホーム画面追加時のフッター高さ不正を修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -515,7 +515,7 @@ const handleTouchEnd = () => {
   right: 0;
   background: white;
   box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
-  padding: 15px 20px calc(15px + var(--safe-area-inset-bottom, min(34px, env(safe-area-inset-bottom))));
+  padding: 15px 20px calc(15px + env(safe-area-inset-bottom, 0px));
   z-index: 1001; /* ナビゲーションバーよりも上に配置 */
 }
 
@@ -593,7 +593,7 @@ const handleTouchEnd = () => {
 
 @media (max-width: 600px) {
   .bottom-bar {
-    padding: 12px 16px calc(12px + var(--safe-area-inset-bottom, min(34px, env(safe-area-inset-bottom))));
+    padding: 12px 16px calc(12px + env(safe-area-inset-bottom, 0px));
   }
 
   .edit-button,


### PR DESCRIPTION
## 問題

iOSでホーム画面に追加（PWAモード）した際、フッター（`.bottom-bar`）の高さがおかしくなる不具合。

## 原因

`.bottom-bar` のpaddingで以下の誤った記述を使用していた：

```css
padding: 15px 20px calc(15px + var(--safe-area-inset-bottom, min(34px, env(safe-area-inset-bottom))));
```

2つの問題があった：
1. `--safe-area-inset-bottom` というCSS変数はどこにも定義されておらず、常にfallbackが使われる
2. `min(34px, env(safe-area-inset-bottom))` という `var()` のfallback内で `min()` と `env()` を組み合わせる記述はiOS Safariで不安定な動作をする

## 修正

sns-memoで正常動作している実装（`env(safe-area-inset-bottom, 0px)` を直接使用）に合わせてシンプルに修正：

```css
/* 修正後 */
padding: 15px 20px calc(15px + env(safe-area-inset-bottom, 0px));

/* モバイル */
padding: 12px 16px calc(12px + env(safe-area-inset-bottom, 0px));
```

これにより `env(safe-area-inset-bottom)` が正しく解決され、ResizeObserverが正確なフッター高さを `--bottom-bar-height` に反映できるようになる。

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4Az98LqPqxstSFJXHi66G)_