### PR TITLE
Firebase Authentication と Firestore の統合

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "check-list",
       "version": "0.0.0",
       "dependencies": {
+        "firebase": "^12.13.0",
         "vue": "^3.5.24"
       },
       "devDependencies": {
@@ -671,6 +672,648 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@firebase/ai": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.12.0.tgz",
+      "integrity": "sha512-b+OL4vdyiSLZL/7dLd67V55CjKJvU9MpNmwnday7eA6GG2+J4iwUEsEHgw0/jKY3A41FfkF0SrnYFvtKbQZ65A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.22",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+      "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+      "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-types": "0.8.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+      "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.12.tgz",
+      "integrity": "sha512-FT+HoNp1NdaZ/N26hCwV3WbxS1m6gTn3p2QRBQ3KH7YqyCQqJx0iT7126RgVk68/Rq+9DeL/zCFnHZ0C4u1nLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.3.tgz",
+      "integrity": "sha512-aJ4DfubWfTO8/2vhEhIAizOoOmiycESTU32e+OUgbWcS/G3PA4Vxlr/9zaiN2wfUG2AptQ7DTvj00tyuFZP5Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.3.tgz",
+      "integrity": "sha512-L3AKIRTJxT9b7cDUH3OyV8gWTnmW3vYkwdzRsukWt4kbPBTct12xalnyvHDkm1lKkr+cQq/4uzBx1bOWsQ2ciw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.3",
+        "@firebase/app-check-types": "0.5.4",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+      "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+      "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.12.tgz",
+      "integrity": "sha512-Pe513OBerK/CIBxz4/za9atd5MsZtd6DzHz4cmqkvkrcDWhQChAoHBpZ3McuZNuSP8YZiKwfX/J1frR07l15/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.12",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+      "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.1"
+      }
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.1.tgz",
+      "integrity": "sha512-/1nkKY/MicI+I9WWcx6R4NKs77AaW9NQ0IwsFdUBomWrW0/cXEmopfM2dtLm2oI1qG6z6vom3CXZDHJIJXoMuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.6.tgz",
+      "integrity": "sha512-KDJ/GAf/rt7galOpn3DRb2buFfGkZCsHTryKjXDG0eeRnok4+2B4nnkMOMdjRnPkElmcJv2Ao0vEA6kp5m98PQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.13.1",
+        "@firebase/auth-types": "0.13.1",
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+      "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+      "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+      "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.0.tgz",
+      "integrity": "sha512-ar9sNOJh5poQCSMSVlnVE8eo8+usTD1POWDCv65omkKUvnFMcdXaQ7J/e7WGKqJzcEMgiezSX/TZiKHZkItMbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+      "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+      "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-types": "1.0.20",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+      "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.5",
+        "@firebase/util": "1.15.1"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.14.1.tgz",
+      "integrity": "sha512-PouS0NJZ3NYOZE/tPDvXa8VUeJ10Ll//7jIdFvMYdhQkd/P3O7nlqhyoTmY0h8Xa9hxg+H0j6gxUytJcoZ9YOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "@firebase/webchannel-wrapper": "1.0.6",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.9.tgz",
+      "integrity": "sha512-NPtBuFr79BbIQJXFWhW4xFC6rBksK8/ewqCTYbbAYfZBDDx0/iHTUj4WpKi5D4d0Pn2Md/3T/e5V9379G5N/Zg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/firestore": "4.14.1",
+        "@firebase/firestore-types": "3.0.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+      "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.4.tgz",
+      "integrity": "sha512-oB5rpm2Emxn2+IS1gRelAeT/5tSZMwM/KhqC5LnJsmTNnS1ZDhD7ZMZNgCI8vchTW6PbaXIwEnpUryGuIQsNbg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.4",
+        "@firebase/auth-interop-types": "0.2.5",
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging-interop-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.4.tgz",
+      "integrity": "sha512-Be+MwhseVf/eFAZwGrFJGok6S7cmsLrAPK8MgyM8LjM0MewTsx2n01WOOca9jio1UsCZOJ0aVyQobnINcdNuIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/functions": "0.13.4",
+        "@firebase/functions-types": "0.6.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+      "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+      "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+      "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-types": "0.5.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+      "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+      "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.26",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.26.tgz",
+      "integrity": "sha512-lHVTO9uLofymHVWkYeUtMddIPcmJvSzVbHRB88W6XKfxbcKF+p3QrfqKhDxremSB4NQjUla1Gwn7d9umSMmt/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/messaging-interop-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.26.tgz",
+      "integrity": "sha512-fn0XvWOfK4tsDLSipwJUW9Cp6ahWA6z+iJHxZ0pHp9MzMSUNQx85yuxZAuI7gkGXfqs7+DqEDHyyS7jDGswrmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/messaging": "0.12.26",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.4.tgz",
+      "integrity": "sha512-wrzITQq+xw5LtygX7O0fu43/k9ABQ4x5H9/sR5m1SbNnhIRI5xd3+raSNJaJkYC4BUhM9A4ZNSnyR2sjhxnb2Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+      "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+      "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-types": "0.2.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+      "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.3.tgz",
+      "integrity": "sha512-ggGKAaLy9YNOvpFoQZgm5p5SiFw3ZFtwti08dojnBQmQicpThTxvG5xZMSpCTYMj2o3gM/yK9CVd2w+kZub8YA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/installations": "0.6.22",
+        "@firebase/logger": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.24.tgz",
+      "integrity": "sha512-EWZTt6fJ7YmPHodQNsSxAIDZY2x8P5kRPvXAc5CmzzBm+NyPFhODbfDsNllDXDL8jlzp50bVWjDY+BXepZS9Mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/logger": "0.5.1",
+        "@firebase/remote-config": "0.8.3",
+        "@firebase/remote-config-types": "0.5.1",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+      "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+      "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+      "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.3",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-types": "0.8.4",
+        "@firebase/util": "1.15.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+      "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+      "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+      "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -782,6 +1425,70 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.53.2",
@@ -1111,6 +1818,15 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.7.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.21.0"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.47.0",
@@ -1671,11 +2387,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -1759,11 +2483,24 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1776,7 +2513,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -1852,6 +2588,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -1904,6 +2646,15 @@
         "@esbuild/win32-arm64": "0.25.12",
         "@esbuild/win32-ia32": "0.25.12",
         "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2185,6 +2936,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2246,6 +3009,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/firebase": {
+      "version": "12.13.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.13.0.tgz",
+      "integrity": "sha512-iutR8ejvAqk6qUClnsPz3U3VIjTWp243AX4cD3iifak5t56to1J29xUIQgSDDzaAqKvhshZerzSahwMQj2TlvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.12.0",
+        "@firebase/analytics": "0.10.22",
+        "@firebase/analytics-compat": "0.2.28",
+        "@firebase/app": "0.14.12",
+        "@firebase/app-check": "0.11.3",
+        "@firebase/app-check-compat": "0.4.3",
+        "@firebase/app-compat": "0.5.12",
+        "@firebase/app-types": "0.9.5",
+        "@firebase/auth": "1.13.1",
+        "@firebase/auth-compat": "0.6.6",
+        "@firebase/data-connect": "0.7.0",
+        "@firebase/database": "1.1.3",
+        "@firebase/database-compat": "2.1.4",
+        "@firebase/firestore": "4.14.1",
+        "@firebase/firestore-compat": "0.4.9",
+        "@firebase/functions": "0.13.4",
+        "@firebase/functions-compat": "0.4.4",
+        "@firebase/installations": "0.6.22",
+        "@firebase/installations-compat": "0.2.22",
+        "@firebase/messaging": "0.12.26",
+        "@firebase/messaging-compat": "0.2.26",
+        "@firebase/performance": "0.7.12",
+        "@firebase/performance-compat": "0.2.25",
+        "@firebase/remote-config": "0.8.3",
+        "@firebase/remote-config-compat": "0.2.24",
+        "@firebase/storage": "0.14.3",
+        "@firebase/storage-compat": "0.4.3",
+        "@firebase/util": "1.15.1"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -2280,6 +3079,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/glob-parent": {
@@ -2335,6 +3143,18 @@
         "he": "bin/he"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2380,6 +3200,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2486,12 +3315,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -2812,6 +3653,30 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.7.tgz",
+      "integrity": "sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2842,6 +3707,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -2930,6 +3804,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -2960,6 +3854,32 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3031,6 +3951,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3081,6 +4007,12 @@
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -3256,6 +4188,35 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3282,12 +4243,65 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
       "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
       "dev": true,
       "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "firebase": "^12.13.0",
     "vue": "^3.5.24"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,19 +2,17 @@
 import { ref, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import NavigationBar, { type NavItem } from './components/NavigationBar.vue'
 import GenericChecklist from './components/GenericChecklist.vue'
+import LoginView from './components/LoginView.vue'
+import { useAuth } from './composables/useAuth'
+import {
+  subscribeChecklistsConfig,
+  saveChecklistsConfig,
+  deleteChecklistData,
+  type ChecklistConfig
+} from './firebase/firestore'
+import type { Unsubscribe } from 'firebase/firestore'
 
-// チェックリスト設定の型定義
-interface ChecklistConfig {
-  id: string
-  label: string
-  initialItems: ChecklistItem[]
-}
-
-// チェックリスト項目の型定義
-interface ChecklistItem {
-  id: string
-  label: string
-}
+const { user, authLoading, signOut } = useAuth()
 
 // デフォルトのチェックリスト設定
 const defaultChecklists: ChecklistConfig[] = [
@@ -50,67 +48,116 @@ const defaultChecklists: ChecklistConfig[] = [
   }
 ]
 
-// チェックリストの設定を管理
 const checklists = ref<ChecklistConfig[]>([])
-
-// アクティブなビューの管理
 const activeView = ref<string>('')
-
-// コンポーネントのrefを管理（動的に生成）
 const checklistRefs = ref<Record<string, InstanceType<typeof GenericChecklist> | null>>({})
-
-// 統計情報の管理
 const stats = ref<{ completedCount: number; totalCount: number }>({
   completedCount: 0,
   totalCount: 0
 })
-
-// 編集モードの管理
 const isEditMode = ref<boolean>(false)
 
+// Firestoreリスナーのアンサブスクライブ関数
+let configUnsubscribe: Unsubscribe | null = null
+// Firestore書き込み中フラグ（無限ループ防止）
+let isSavingToFirestore = false
+// Firestoreから受信した最新データのJSON（重複書き込み防止）
+let lastFirestoreJson = ''
+
 // ローカルストレージからチェックリスト設定を読み込む
-const loadChecklists = () => {
+const loadFromLocalStorage = () => {
   const saved = localStorage.getItem('checklists-config')
   if (saved) {
     try {
       const parsed = JSON.parse(saved)
       checklists.value = parsed
-      // アクティブビューを最初のチェックリストに設定
       if (checklists.value.length > 0) {
         activeView.value = checklists.value[0].id
       }
-    } catch (e) {
-      console.error('Failed to load checklists config:', e)
+    } catch {
       checklists.value = [...defaultChecklists]
       activeView.value = checklists.value[0].id
     }
   } else {
-    // 初回起動時はデフォルトを使用
     checklists.value = [...defaultChecklists]
     activeView.value = checklists.value[0].id
-    saveChecklists()
+    localStorage.setItem('checklists-config', JSON.stringify(checklists.value))
   }
 }
 
-// チェックリスト設定をローカルストレージに保存
-const saveChecklists = () => {
+const saveToLocalStorage = () => {
   localStorage.setItem('checklists-config', JSON.stringify(checklists.value))
 }
 
-// チェックリスト設定が変更されたら保存
+// Firestoreにチェックリスト設定を保存
+const saveToFirestore = async (uid: string) => {
+  const json = JSON.stringify(checklists.value)
+  if (json === lastFirestoreJson) return
+  isSavingToFirestore = true
+  try {
+    await saveChecklistsConfig(uid, checklists.value)
+    lastFirestoreJson = json
+  } finally {
+    isSavingToFirestore = false
+  }
+}
+
+// Firestoreのリアルタイム購読を開始
+const startFirestoreSync = (uid: string) => {
+  stopFirestoreSync()
+  configUnsubscribe = subscribeChecklistsConfig(uid, (remoteChecklists) => {
+    if (isSavingToFirestore) return
+
+    if (remoteChecklists) {
+      const json = JSON.stringify(remoteChecklists)
+      if (json === lastFirestoreJson) return
+      lastFirestoreJson = json
+      checklists.value = remoteChecklists
+      // activeView が存在しなければ先頭に設定
+      if (!checklists.value.find(c => c.id === activeView.value) && checklists.value.length > 0) {
+        activeView.value = checklists.value[0].id
+      }
+    } else {
+      // Firestoreにデータがない場合、ローカルストレージのデータをアップロード
+      saveToFirestore(uid)
+    }
+  })
+}
+
+const stopFirestoreSync = () => {
+  if (configUnsubscribe) {
+    configUnsubscribe()
+    configUnsubscribe = null
+  }
+}
+
+// 認証状態が変わったときの処理
+watch(user, (newUser, oldUser) => {
+  if (newUser) {
+    // ログイン時：Firestoreの購読を開始
+    startFirestoreSync(newUser.uid)
+  } else if (oldUser && !newUser) {
+    // ログアウト時：Firestoreの購読を停止してローカルストレージから読み込み
+    stopFirestoreSync()
+    lastFirestoreJson = ''
+    loadFromLocalStorage()
+  }
+})
+
+// チェックリスト設定が変わったらどちらにも保存
 watch(checklists, () => {
-  saveChecklists()
+  saveToLocalStorage()
+  if (user.value && !isSavingToFirestore) {
+    saveToFirestore(user.value.uid)
+  }
 }, { deep: true })
 
-// フッター要素の ref と ResizeObserver
 const bottomBarEl = ref<HTMLElement | null>(null)
 let bottomBarObserver: ResizeObserver | null = null
 
-// コンポーネントマウント時にチェックリストを読み込む
 onMounted(() => {
-  loadChecklists()
+  loadFromLocalStorage()
 
-  // フッターの実際の高さを CSS 変数に反映し、view-container の bottom を動的に設定する
   if (bottomBarEl.value) {
     const applyHeight = () => {
       if (bottomBarEl.value) {
@@ -128,30 +175,24 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   bottomBarObserver?.disconnect()
+  stopFirestoreSync()
 })
 
-// ナビゲーション項目を計算
-const navItems = computed<NavItem[]>(() => 
+const navItems = computed<NavItem[]>(() =>
   checklists.value.map(c => ({ id: c.id, label: c.label }))
 )
 
-// 統計情報の更新ハンドラー
 const handleStatsUpdate = (newStats: { completedCount: number; totalCount: number }) => {
   stats.value = newStats
 }
 
-// リセットボタンのハンドラー
 const handleReset = () => {
   const ref = checklistRefs.value[activeView.value]
-  if (ref) {
-    ref.handleReset()
-  }
+  if (ref) ref.handleReset()
 }
 
-// 編集ボタンのハンドラー
 const handleEdit = () => {
   isEditMode.value = !isEditMode.value
-  
   const ref = checklistRefs.value[activeView.value]
   if (ref) {
     if (isEditMode.value) {
@@ -162,100 +203,85 @@ const handleEdit = () => {
   }
 }
 
-// ビュー切り替え時に編集モードをリセット
 const handleNavChangeWithEditReset = (viewId: string) => {
-  // 編集モードをオフにする
   if (isEditMode.value) {
     const currentRef = checklistRefs.value[activeView.value]
-    if (currentRef) {
-      currentRef.disableEditMode()
-    }
+    if (currentRef) currentRef.disableEditMode()
     isEditMode.value = false
   }
-  
-  // 元のナビゲーション処理を実行
   handleNavChange(viewId)
 }
 
-// 現在のインデックスを計算
-const currentIndex = computed(() => 
+const currentIndex = computed(() =>
   checklists.value.findIndex(c => c.id === activeView.value)
 )
 
-// ナビゲーション変更ハンドラー
 const handleNavChange = (viewId: string) => {
   activeView.value = viewId
-  // ナビゲーション変更時はスライドオフセットをリセット
   translateX.value = 0
   isTransitioning.value = false
 }
 
-// リセットまたはリスト削除ボタンのハンドラー
 const handleResetOrDelete = () => {
   if (isEditMode.value) {
-    // 編集モード時はリストを削除
     handleDeleteChecklist(activeView.value)
   } else {
-    // 通常モード時はリセット
     handleReset()
   }
 }
+
 const handleAddChecklist = () => {
   const name = prompt('新しいチェックリストの名前を入力してください：')
   if (!name || !name.trim()) return
-  
+
   const newId = `checklist-${Date.now()}`
   const newChecklist: ChecklistConfig = {
     id: newId,
     label: name.trim(),
     initialItems: []
   }
-  
   checklists.value.push(newChecklist)
-  // 新しいチェックリストに切り替え
   activeView.value = newId
 }
 
-// チェックリストを削除
 const handleDeleteChecklist = (id: string) => {
   if (checklists.value.length <= 1) {
     alert('最後のチェックリストは削除できません')
     return
   }
-  
+
   const checklist = checklists.value.find(c => c.id === id)
   if (!checklist) return
-  
+
   if (!confirm(`「${checklist.label}」を削除しますか？\n\n注意: チェックリスト内のすべてのデータが削除されます。`)) {
     return
   }
-  
-  // チェックリストを削除
+
   const index = checklists.value.findIndex(c => c.id === id)
   checklists.value.splice(index, 1)
-  
-  // ローカルストレージからチェックリストデータを削除
-  // カスタムアイテム
+
+  // ローカルストレージから削除
   localStorage.removeItem(`${id}-custom-items`)
-  // 並び順
   localStorage.removeItem(`${id}-order`)
-  
-  // アクティブビューが削除されたチェックリストだった場合、最初のチェックリストに切り替え
+
+  // Firestoreからも削除
+  if (user.value) {
+    deleteChecklistData(user.value.uid, id).catch(console.error)
+  }
+
   if (activeView.value === id) {
     activeView.value = checklists.value[0].id
   }
 }
 
-// チェックリスト名を更新
 const handleUpdateChecklistName = (id: string, newName: string) => {
   const checklist = checklists.value.find(c => c.id === id)
   if (checklist) {
     checklist.label = newName
-    // チェックリスト設定の変更がwatchで自動的に保存される
   }
 }
 
-// スワイプ機能の実装
+// スワイプ機能
 const touchStartX = ref<number>(0)
 const touchStartY = ref<number>(0)
 const touchCurrentX = ref<number>(0)
@@ -264,16 +290,13 @@ const translateX = ref<number>(0)
 const isTransitioning = ref<boolean>(false)
 const isSwiping = ref<boolean>(false)
 const swipeDirection = ref<'horizontal' | 'vertical' | null>(null)
-const swipeThreshold = 100 // 画面遷移を確定するしきい値（ピクセル）
-const directionThreshold = 10 // スワイプ方向を判定するしきい値（ピクセル）
-const edgeResistance = 0.3 // 端での抵抗感の係数
-const transitionDuration = 300 // トランジション時間（ミリ秒）
+const swipeThreshold = 100
+const directionThreshold = 10
+const edgeResistance = 0.3
+const transitionDuration = 300
 
-// タッチ開始イベント
 const handleTouchStart = (e: TouchEvent) => {
-  // 編集モード中は横スワイプを無効化
   if (isEditMode.value) return
-  
   if (e.touches.length > 0) {
     touchStartX.value = e.touches[0].clientX
     touchStartY.value = e.touches[0].clientY
@@ -285,26 +308,18 @@ const handleTouchStart = (e: TouchEvent) => {
   }
 }
 
-// スワイプ方向を判定する関数
 const determineSwipeDirection = (diffX: number, diffY: number, threshold: number): 'horizontal' | 'vertical' | null => {
   const absDiffX = Math.abs(diffX)
   const absDiffY = Math.abs(diffY)
-
-  // 十分な移動量がある場合にのみ方向を判定
   const totalMovement = Math.hypot(absDiffX, absDiffY)
   if (totalMovement > threshold) {
-    // 横方向の移動が縦方向より大きい場合は横スワイプ
     return absDiffX > absDiffY ? 'horizontal' : 'vertical'
   }
-
   return null
 }
 
-// タッチ移動イベント - リアルタイムでスライド
 const handleTouchMove = (e: TouchEvent) => {
-  // 編集モード中は横スワイプを無効化
   if (isEditMode.value) return
-  
   if (!isSwiping.value || e.touches.length === 0) return
 
   touchCurrentX.value = e.touches[0].clientX
@@ -313,27 +328,17 @@ const handleTouchMove = (e: TouchEvent) => {
   const diffX = touchCurrentX.value - touchStartX.value
   const diffY = touchCurrentY.value - touchStartY.value
 
-  // スワイプ方向がまだ判定されていない場合、判定する
   if (swipeDirection.value === null) {
     swipeDirection.value = determineSwipeDirection(diffX, diffY, directionThreshold)
   }
 
-  // 縦スクロールの場合は、スワイプ処理をスキップ
-  if (swipeDirection.value === 'vertical') {
-    return
-  }
+  if (swipeDirection.value === 'vertical') return
 
-  // 横スワイプの場合のみ、スライド処理を実行
   if (swipeDirection.value === 'horizontal') {
-    // 横スワイプの場合は縦スクロールを防止
     e.preventDefault()
-
     const currentIdx = currentIndex.value
-
-    // 端の画面では逆方向のスワイプを制限
     if ((currentIdx === 0 && diffX > 0) ||
         (currentIdx === checklists.value.length - 1 && diffX < 0)) {
-      // 端での抵抗感を表現（スワイプ量を減衰）
       translateX.value = diffX * edgeResistance
     } else {
       translateX.value = diffX
@@ -341,24 +346,19 @@ const handleTouchMove = (e: TouchEvent) => {
   }
 }
 
-// スワイプ状態をリセットするヘルパー関数
 const resetSwipeState = () => {
   isSwiping.value = false
   swipeDirection.value = null
   translateX.value = 0
 }
 
-// タッチ終了イベント
 const handleTouchEnd = () => {
-  // 編集モード中は横スワイプを無効化
   if (isEditMode.value) {
     isSwiping.value = false
     return
   }
-  
   if (!isSwiping.value) return
 
-  // 縦スクロールの場合は、スワイプ処理をスキップ
   if (swipeDirection.value === 'vertical') {
     resetSwipeState()
     return
@@ -369,22 +369,16 @@ const handleTouchEnd = () => {
 
   isTransitioning.value = true
 
-  // 横スワイプの場合のみ、画面遷移を実行
   if (swipeDirection.value === 'horizontal') {
-    // 右スワイプ（前の画面へ）
     if (swipeDistance > swipeThreshold && currentIdx > 0) {
       activeView.value = checklists.value[currentIdx - 1].id
-    }
-    // 左スワイプ（次の画面へ）
-    else if (swipeDistance < -swipeThreshold && currentIdx < checklists.value.length - 1) {
+    } else if (swipeDistance < -swipeThreshold && currentIdx < checklists.value.length - 1) {
       activeView.value = checklists.value[currentIdx + 1].id
     }
   }
 
-  // スワイプ状態をリセット
   resetSwipeState()
 
-  // トランジション完了後にフラグをリセット
   setTimeout(() => {
     isTransitioning.value = false
   }, transitionDuration)
@@ -392,7 +386,17 @@ const handleTouchEnd = () => {
 </script>
 
 <template>
+  <!-- ローディング中 -->
+  <div v-if="authLoading" class="loading-screen">
+    <div class="loading-spinner"></div>
+  </div>
+
+  <!-- 未ログイン -->
+  <LoginView v-else-if="!user" />
+
+  <!-- ログイン済み -->
   <div
+    v-else
     class="app"
     @touchstart="handleTouchStart"
     @touchmove="handleTouchMove"
@@ -402,9 +406,11 @@ const handleTouchEnd = () => {
       :active-item="activeView"
       :nav-items="navItems"
       :is-edit-mode="isEditMode"
+      :user="user"
       @nav-change="handleNavChangeWithEditReset"
       @add-checklist="handleAddChecklist"
       @update-checklist-name="handleUpdateChecklistName"
+      @sign-out="signOut"
     />
     <div class="view-container">
       <div
@@ -424,6 +430,7 @@ const handleTouchEnd = () => {
             :checklist-id="checklist.id"
             :initial-items="checklist.initialItems"
             :is-active="activeView === checklist.id"
+            :uid="user.uid"
             @update:stats="handleStatsUpdate"
           />
         </div>
@@ -434,15 +441,15 @@ const handleTouchEnd = () => {
         {{ stats.completedCount }} / {{ stats.totalCount }} 完了
       </div>
       <div class="button-group">
-        <button 
+        <button
           class="edit-button"
           :class="{ active: isEditMode }"
           @click="handleEdit"
         >
           {{ isEditMode ? '編集完了' : '項目を編集' }}
         </button>
-        <button 
-          :class="isEditMode ? 'delete-list-button' : 'reset-button'" 
+        <button
+          :class="isEditMode ? 'delete-list-button' : 'reset-button'"
           @click="handleResetOrDelete"
         >
           {{ isEditMode ? 'リストを削除' : 'すべてリセット' }}
@@ -453,31 +460,52 @@ const handleTouchEnd = () => {
 </template>
 
 <style scoped>
+/* ローディング画面 */
+.loading-screen {
+  height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+.loading-spinner {
+  width: 48px;
+  height: 48px;
+  border: 4px solid rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
 .app {
   height: 100dvh;
   display: flex;
   flex-direction: column;
   overflow-x: hidden;
-  touch-action: pan-y; /* 垂直スクロールのみを許可 */
+  touch-action: pan-y;
   position: relative;
-  /* ナビゲーションバーの高さを定義 */
   --nav-bar-height: calc(6px + env(safe-area-inset-top) + 10px + 14px + 10px + 6px);
 }
 
 .view-container {
   position: absolute;
-  top: var(--nav-bar-height); /* ナビゲーションバーの直下から開始 */
+  top: var(--nav-bar-height);
   bottom: var(--bottom-bar-height, 100px);
   left: 0;
   right: 0;
   display: flex;
   justify-content: flex-start;
   align-items: stretch;
-  overflow-x: hidden; /* 横スクロールは無効 */
-  overflow-y: auto; /* 縦スクロールを有効化 */
-  user-select: none; /* スワイプ時のテキスト選択を防止 */
-  -webkit-user-select: none; /* Safari用 */
-  -moz-user-select: none; /* Firefox用 */
+  overflow-x: hidden;
+  overflow-y: auto;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
 }
 
 .view-slider {
@@ -494,12 +522,11 @@ const handleTouchEnd = () => {
   align-items: flex-start;
   padding: 20px;
   box-sizing: border-box;
-  min-height: 100%; /* 最小高さを100%に設定 */
+  min-height: 100%;
 }
 
 @media (max-width: 600px) {
   .app {
-    /* スマートフォン用のナビゲーションバーの高さ */
     --nav-bar-height: calc(6px + env(safe-area-inset-top) + 8px + 13px + 8px + 6px);
   }
 
@@ -516,7 +543,7 @@ const handleTouchEnd = () => {
   background: white;
   box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
   padding: 15px 20px calc(15px + env(safe-area-inset-bottom, 0px));
-  z-index: 1001; /* ナビゲーションバーよりも上に配置 */
+  z-index: 1001;
 }
 
 .progress {
@@ -541,11 +568,9 @@ const handleTouchEnd = () => {
   font-size: 1.1em;
   cursor: pointer;
   transition: all 0.3s ease;
-  /* 文字選択を無効化 */
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
-  /* 押下時のハイライトを無効化 */
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -579,11 +604,9 @@ const handleTouchEnd = () => {
   transition: all 0.3s ease;
   background: #dc3545;
   color: white;
-  /* 文字選択を無効化 */
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
-  /* 押下時のハイライトを無効化 */
   -webkit-tap-highlight-color: transparent;
 }
 

--- a/src/components/GenericChecklist.vue
+++ b/src/components/GenericChecklist.vue
@@ -1,15 +1,24 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, nextTick } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
+import {
+  subscribeChecklistData,
+  saveChecklistData,
+  type ChecklistItem,
+  type ChecklistData
+} from '../firebase/firestore'
+import type { Unsubscribe } from 'firebase/firestore'
 
 // Props定義
 interface Props {
-  checklistId: string  // チェックリストを識別するID（localStorageのキーに使用）
-  initialItems: ChecklistItem[]  // 初期項目
+  checklistId: string
+  initialItems: ChecklistItem[]
   isActive?: boolean
+  uid?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  isActive: false
+  isActive: false,
+  uid: ''
 })
 
 // Emits定義
@@ -19,12 +28,6 @@ interface Emits {
 
 const emit = defineEmits<Emits>()
 
-// チェックリスト項目の型定義
-interface ChecklistItem {
-  id: string
-  label: string
-}
-
 // 並べ替え可能な項目リスト
 const checklistItems = ref<ChecklistItem[]>([...props.initialItems])
 
@@ -32,11 +35,10 @@ const checklistItems = ref<ChecklistItem[]>([...props.initialItems])
 const checkedItems = ref<Record<string, boolean>>({})
 
 // 編集状態の管理
-const isEditMode = ref<boolean>(false) // 編集モードのフラグ
+const isEditMode = ref<boolean>(false)
 const editingItemId = ref<string | null>(null)
 const editingText = ref<string>('')
 const customLabels = ref<Record<string, string>>({})
-// 編集中の入力フィールドへの参照（一度に1つの項目のみ編集可能）
 let editInputElement: HTMLInputElement | null = null
 const setEditInputRef = (el: Element | object | null) => {
   if (el instanceof HTMLInputElement) {
@@ -50,112 +52,213 @@ const setEditInputRef = (el: Element | object | null) => {
 const draggingItemId = ref<string | null>(null)
 const dragStartY = ref<number>(0)
 const dragCurrentY = ref<number>(0)
-const dragOffsetY = ref<number>(0) // ドラッグ中の要素の視覚的な移動量
+const dragOffsetY = ref<number>(0)
 const longPressTimer = ref<number | null>(null)
 const isDragging = ref<boolean>(false)
 const dragItemIndex = ref<number>(-1)
-const DRAG_START_DELAY = 0 // ドラッグ開始遅延時間（ミリ秒）- タッチの瞬間から並べ替え可能
-const itemRefs = ref<(HTMLElement | null)[]>([]) // 各アイテムのDOM要素参照
+const DRAG_START_DELAY = 0
+const itemRefs = ref<(HTMLElement | null)[]>([])
 
-// ユーザーが追加したカスタムアイテムをローカルストレージから読み込む
-const loadCustomItems = (): ChecklistItem[] => {
-  const savedCustomItems = localStorage.getItem(`${props.checklistId}-custom-items`)
-  if (savedCustomItems) {
-    try {
-      return JSON.parse(savedCustomItems)
-    } catch (e) {
-      console.error('Failed to load custom items:', e)
-      return []
-    }
+// Firestore 同期関連
+let firestoreUnsubscribe: Unsubscribe | null = null
+let isSavingToFirestore = false
+let lastFirestoreJson = ''
+
+// ---- LocalStorage ヘルパー ----
+const loadCustomItemsFromLS = (): ChecklistItem[] => {
+  const saved = localStorage.getItem(`${props.checklistId}-custom-items`)
+  if (saved) {
+    try { return JSON.parse(saved) } catch { return [] }
   }
   return []
 }
 
-// カスタムアイテムをローカルストレージに保存
-const saveCustomItems = (customItems: ChecklistItem[]) => {
-  localStorage.setItem(`${props.checklistId}-custom-items`, JSON.stringify(customItems))
+const saveCustomItemsToLS = (items: ChecklistItem[]) => {
+  localStorage.setItem(`${props.checklistId}-custom-items`, JSON.stringify(items))
 }
 
-// すべてのアイテム（初期アイテム + カスタムアイテム）を取得
 const getAllItems = (): ChecklistItem[] => {
-  const customItems = loadCustomItems()
-  return [...props.initialItems, ...customItems]
+  return [...props.initialItems, ...loadCustomItemsFromLS()]
 }
 
-// ローカルストレージから並び順を読み込む
-const loadItemOrder = () => {
+const loadItemOrderFromLS = () => {
   const allItems = getAllItems()
   const savedOrder = localStorage.getItem(`${props.checklistId}-order`)
   if (savedOrder) {
     try {
       const orderIds: string[] = JSON.parse(savedOrder)
-      // 保存された順序に従ってアイテムを並べ替え
       const orderedItems: ChecklistItem[] = []
       orderIds.forEach(id => {
-        const item = allItems.find(item => item.id === id)
-        if (item) {
-          orderedItems.push(item)
-        }
+        const item = allItems.find(i => i.id === id)
+        if (item) orderedItems.push(item)
       })
-      // 新しく追加されたアイテムがある場合は末尾に追加
       allItems.forEach(item => {
-        if (!orderIds.includes(item.id)) {
-          orderedItems.push(item)
-        }
+        if (!orderIds.includes(item.id)) orderedItems.push(item)
       })
       checklistItems.value = orderedItems
-    } catch (e) {
-      console.error('Failed to load item order:', e)
+    } catch {
       checklistItems.value = allItems
     }
   } else {
-    // 保存された順序がない場合は全アイテムを使用
     checklistItems.value = allItems
   }
 }
 
-// 並び順をローカルストレージに保存
-const saveItemOrder = () => {
-  const orderIds = checklistItems.value.map(item => item.id)
+const saveItemOrderToLS = () => {
+  const orderIds = checklistItems.value.map(i => i.id)
   localStorage.setItem(`${props.checklistId}-order`, JSON.stringify(orderIds))
 }
 
-// ローカルストレージからチェック状態を読み込む
-const loadCheckedState = () => {
+const loadCheckedStateFromLS = () => {
   const saved: Record<string, boolean> = {}
   checklistItems.value.forEach(item => {
-    const value = localStorage.getItem(`${props.checklistId}-${item.id}`)
-    saved[item.id] = value === 'true'
+    const val = localStorage.getItem(`${props.checklistId}-${item.id}`)
+    saved[item.id] = val === 'true'
   })
   checkedItems.value = saved
 }
 
-// ローカルストレージからカスタムラベルを読み込む
-const loadCustomLabels = () => {
+const loadCustomLabelsFromLS = () => {
   const saved: Record<string, string> = {}
   checklistItems.value.forEach(item => {
-    const value = localStorage.getItem(`${props.checklistId}-${item.id}-label`)
-    if (value) {
-      saved[item.id] = value
-    }
+    const val = localStorage.getItem(`${props.checklistId}-${item.id}-label`)
+    if (val) saved[item.id] = val
   })
   customLabels.value = saved
 }
 
-// コンポーネントマウント時に状態を読み込む
-onMounted(() => {
-  loadItemOrder()
-  loadCheckedState()
-  loadCustomLabels()
+// ---- Firestore ヘルパー ----
+
+// 現在の状態を ChecklistData にまとめる
+const buildChecklistData = (): ChecklistData => {
+  // customItems = checklistItems のうち initialItems に含まれないもの
+  const initialIds = new Set(props.initialItems.map(i => i.id))
+  const customItems = checklistItems.value.filter(i => !initialIds.has(i.id))
+  return {
+    customItems,
+    order: checklistItems.value.map(i => i.id),
+    checkedItems: { ...checkedItems.value },
+    customLabels: { ...customLabels.value }
+  }
+}
+
+// Firestoreに保存（重複保存を避けるためdebounce的に制御）
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+const scheduleSaveToFirestore = () => {
+  if (!props.uid) return
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(async () => {
+    if (!props.uid) return
+    const data = buildChecklistData()
+    const json = JSON.stringify(data)
+    if (json === lastFirestoreJson) return
+    isSavingToFirestore = true
+    try {
+      await saveChecklistData(props.uid, props.checklistId, data)
+      lastFirestoreJson = json
+    } catch (e) {
+      console.error('Firestore save failed:', e)
+    } finally {
+      isSavingToFirestore = false
+    }
+  }, 500)
+}
+
+// Firestoreのデータを状態に適用
+const applyFirestoreData = (data: ChecklistData) => {
+  const allInitialItems = [...props.initialItems]
+  const customItemMap = new Map(data.customItems.map(i => [i.id, i]))
+
+  // order に従って並べ替え
+  const allItems: ChecklistItem[] = []
+  data.order.forEach(id => {
+    const initial = allInitialItems.find(i => i.id === id)
+    if (initial) {
+      allItems.push(initial)
+    } else if (customItemMap.has(id)) {
+      allItems.push(customItemMap.get(id)!)
+    }
+  })
+  // order に含まれていないものを末尾に追加
+  allInitialItems.forEach(i => {
+    if (!data.order.includes(i.id)) allItems.push(i)
+  })
+  data.customItems.forEach(i => {
+    if (!data.order.includes(i.id)) allItems.push(i)
+  })
+
+  checklistItems.value = allItems
+  checkedItems.value = { ...data.checkedItems }
+  customLabels.value = { ...data.customLabels }
+
+  // ローカルストレージにもキャッシュ
+  saveItemOrderToLS()
+  saveCustomItemsToLS(data.customItems)
+  Object.entries(data.checkedItems).forEach(([id, checked]) => {
+    localStorage.setItem(`${props.checklistId}-${id}`, String(checked))
+  })
+  Object.entries(data.customLabels).forEach(([id, label]) => {
+    localStorage.setItem(`${props.checklistId}-${id}-label`, label)
+  })
+}
+
+// Firestoreの購読を開始
+const startFirestoreSync = () => {
+  if (!props.uid) return
+  stopFirestoreSync()
+  firestoreUnsubscribe = subscribeChecklistData(props.uid, props.checklistId, (data) => {
+    if (isSavingToFirestore) return
+    if (data) {
+      const json = JSON.stringify(data)
+      if (json === lastFirestoreJson) return
+      lastFirestoreJson = json
+      applyFirestoreData(data)
+    } else {
+      // Firestoreにデータがなければローカルのデータをアップロード
+      scheduleSaveToFirestore()
+    }
+  })
+}
+
+const stopFirestoreSync = () => {
+  if (firestoreUnsubscribe) {
+    firestoreUnsubscribe()
+    firestoreUnsubscribe = null
+  }
+}
+
+// uid が変わったら購読を再設定
+watch(() => props.uid, (newUid) => {
+  if (newUid) {
+    startFirestoreSync()
+  } else {
+    stopFirestoreSync()
+  }
 })
 
-// チェック状態が変わったらローカルストレージに保存
+// コンポーネントマウント時に状態を読み込む
+onMounted(() => {
+  loadItemOrderFromLS()
+  loadCheckedStateFromLS()
+  loadCustomLabelsFromLS()
+  if (props.uid) {
+    startFirestoreSync()
+  }
+})
+
+onUnmounted(() => {
+  stopFirestoreSync()
+  if (saveTimer) clearTimeout(saveTimer)
+})
+
+// チェック状態が変わったらローカルストレージ & Firestore に保存
 watch(
   checkedItems,
   (newValue) => {
     Object.entries(newValue).forEach(([id, checked]) => {
       localStorage.setItem(`${props.checklistId}-${id}`, String(checked))
     })
+    scheduleSaveToFirestore()
   },
   { deep: true }
 )
@@ -172,14 +275,10 @@ const handleCheckChange = (id: string) => {
 const startEdit = async (id: string) => {
   editingItemId.value = id
   editingText.value = customLabels.value[id] || checklistItems.value.find(item => item.id === id)?.label || ''
-  
-  // 次のティックで入力フィールドを表示してスクロール
   await nextTick()
-  // 初回のnextTick後、さらに確実にrefが利用可能になるまで待つ
   await nextTick()
   if (editInputElement) {
     editInputElement.focus()
-    // 入力フィールドが画面内に表示されるようスクロール
     editInputElement.scrollIntoView({ behavior: 'smooth', block: 'center' })
   }
 }
@@ -189,12 +288,9 @@ const cancelEdit = () => {
   const currentId = editingItemId.value
   editingItemId.value = null
   editingText.value = ''
-  
-  // 編集中のアイテムが空のラベルを持つ新規アイテムの場合は削除
   if (currentId) {
     const item = checklistItems.value.find(item => item.id === currentId)
     if (item && item.label === '' && !customLabels.value[currentId]) {
-      // 新規追加途中でキャンセルされたアイテムを削除
       checklistItems.value = checklistItems.value.filter(item => item.id !== currentId)
     }
   }
@@ -204,36 +300,22 @@ const cancelEdit = () => {
 const saveEdit = (id: string) => {
   const trimmedText = editingText.value.trim()
   if (trimmedText) {
-    // テキストがある場合は保存
-    customLabels.value = {
-      ...customLabels.value,
-      [id]: trimmedText
-    }
+    customLabels.value = { ...customLabels.value, [id]: trimmedText }
     localStorage.setItem(`${props.checklistId}-${id}-label`, trimmedText)
-    
-    // 新規アイテムの場合はカスタムアイテムとして永続化
+
     const item = checklistItems.value.find(item => item.id === id)
     if (item && item.label === '') {
-      // 新規アイテムをカスタムアイテムとして保存
-      const customItems = loadCustomItems()
-      const newItem: ChecklistItem = {
-        id: id,
-        label: trimmedText
-      }
+      const customItems = loadCustomItemsFromLS()
+      const newItem: ChecklistItem = { id, label: trimmedText }
       customItems.push(newItem)
-      saveCustomItems(customItems)
-      
-      // アイテムのラベルを更新
+      saveCustomItemsToLS(customItems)
       item.label = trimmedText
-      
-      // 並び順を保存
-      saveItemOrder()
+      saveItemOrderToLS()
     }
+    scheduleSaveToFirestore()
   } else {
-    // テキストが空の場合
     const item = checklistItems.value.find(item => item.id === id)
     if (item && item.label === '') {
-      // 新規追加途中で空のまま保存しようとした場合は削除
       checklistItems.value = checklistItems.value.filter(item => item.id !== id)
     }
   }
@@ -243,66 +325,44 @@ const saveEdit = (id: string) => {
 
 // 新しいアイテムを追加
 const addNewItem = async () => {
-  // 新しいアイテムのIDを生成（タイムスタンプベース）
   const newId = `${props.checklistId}-custom-${Date.now()}`
-  const newItem: ChecklistItem = {
-    id: newId,
-    label: ''
-  }
-  
-  // アイテムリストに追加（一時的）
-  checklistItems.value.push(newItem)
-  
-  // 自動的に編集モードに入る
+  checklistItems.value.push({ id: newId, label: '' })
   await nextTick()
   await startEdit(newId)
 }
 
 // アイテムを削除
 const deleteItem = (id: string) => {
-  // 初期アイテムかどうかをチェック
   const isInitialItem = props.initialItems.some(item => item.id === id)
-  
   if (isInitialItem) {
-    // 初期アイテムの場合は確認ダイアログを表示
-    if (!confirm('初期項目を削除しますか？\n（削除しても初期項目は再読み込み時に復元できます）')) {
-      return
-    }
+    if (!confirm('初期項目を削除しますか？\n（削除しても初期項目は再読み込み時に復元できます）')) return
   } else {
-    // カスタムアイテムの場合も確認
-    if (!confirm('この項目を削除しますか？')) {
-      return
-    }
+    if (!confirm('この項目を削除しますか？')) return
   }
-  
-  // アイテムリストから削除
+
   checklistItems.value = checklistItems.value.filter(item => item.id !== id)
-  
-  // カスタムアイテムの場合はローカルストレージからも削除
+
   if (!isInitialItem) {
-    const customItems = loadCustomItems()
-    const updatedCustomItems = customItems.filter(item => item.id !== id)
-    saveCustomItems(updatedCustomItems)
+    const customItems = loadCustomItemsFromLS()
+    saveCustomItemsToLS(customItems.filter(item => item.id !== id))
   }
-  
-  // チェック状態を削除
+
   if (checkedItems.value[id]) {
     const newCheckedItems = { ...checkedItems.value }
     delete newCheckedItems[id]
     checkedItems.value = newCheckedItems
     localStorage.removeItem(`${props.checklistId}-${id}`)
   }
-  
-  // カスタムラベルを削除
+
   if (customLabels.value[id]) {
     const newCustomLabels = { ...customLabels.value }
     delete newCustomLabels[id]
     customLabels.value = newCustomLabels
     localStorage.removeItem(`${props.checklistId}-${id}-label`)
   }
-  
-  // 並び順を保存
-  saveItemOrder()
+
+  saveItemOrderToLS()
+  scheduleSaveToFirestore()
 }
 
 // 表示用のラベルを取得
@@ -310,42 +370,32 @@ const getDisplayLabel = (item: ChecklistItem): string => {
   return customLabels.value[item.id] || item.label
 }
 
-// 要素の実際の高さ（マージンを含む）を取得
 const getElementTotalHeight = (element: HTMLElement): number => {
   const height = element.offsetHeight
   const style = window.getComputedStyle(element)
-  const marginTop = parseFloat(style.marginTop)
-  const marginBottom = parseFloat(style.marginBottom)
-  return height + marginTop + marginBottom
+  return height + parseFloat(style.marginTop) + parseFloat(style.marginBottom)
 }
 
 // 長押し開始
 const handleTouchStart = (e: TouchEvent, itemId: string, index: number) => {
-  // 編集中の項目がある場合は長押しを無効化
   if (editingItemId.value !== null) return
-  
-  // 編集モードでない場合は長押しを無効化
   if (!isEditMode.value) return
-  
   if (!e.touches.length) return
-  
+
   dragStartY.value = e.touches[0].clientY
   dragCurrentY.value = e.touches[0].clientY
   dragItemIndex.value = index
-  
-  // ドラッグ開始タイマーを開始
+
   longPressTimer.value = window.setTimeout(() => {
     draggingItemId.value = itemId
     isDragging.value = true
   }, DRAG_START_DELAY)
 }
 
-// タッチ移動
 const handleTouchMove = (e: TouchEvent) => {
   if (!e.touches.length) return
-  
+
   if (!isDragging.value) {
-    // ドラッグ開始前に移動した場合はドラッグをキャンセル
     const moveDistance = Math.abs(e.touches[0].clientY - dragStartY.value)
     if (moveDistance > 10 && longPressTimer.value !== null) {
       window.clearTimeout(longPressTimer.value)
@@ -353,27 +403,19 @@ const handleTouchMove = (e: TouchEvent) => {
     }
     return
   }
-  
+
   e.preventDefault()
   dragCurrentY.value = e.touches[0].clientY
-  
-  // ドラッグ中の要素の視覚的な移動量を更新（指に追従させる）
   dragOffsetY.value = dragCurrentY.value - dragStartY.value
-  
-  // ドラッグ中の要素の位置を更新
+
   const currentIndex = checklistItems.value.findIndex(item => item.id === draggingItemId.value)
-  
   if (currentIndex === -1) return
-  
-  // 累積ドラッグ距離を計算
+
   const totalDragDistance = dragCurrentY.value - dragStartY.value
-  
-  // 実際のアイテムの高さを取得して、移動先のインデックスを計算
   let accumulatedHeight = 0
   let newIndex = dragItemIndex.value
-  
+
   if (totalDragDistance > 0) {
-    // 下方向へのドラッグ
     for (let i = dragItemIndex.value + 1; i < checklistItems.value.length; i++) {
       const itemElement = itemRefs.value[i]
       if (itemElement) {
@@ -387,7 +429,6 @@ const handleTouchMove = (e: TouchEvent) => {
       }
     }
   } else if (totalDragDistance < 0) {
-    // 上方向へのドラッグ
     for (let i = dragItemIndex.value - 1; i >= 0; i--) {
       const itemElement = itemRefs.value[i]
       if (itemElement) {
@@ -401,55 +442,43 @@ const handleTouchMove = (e: TouchEvent) => {
       }
     }
   }
-  
-  // インデックスが変わった場合、アイテムを入れ替え
+
   if (newIndex !== currentIndex) {
-    // 並べ替え前に高さの差分を計算（マージンを含む）
     let heightDiff = 0
     if (newIndex > currentIndex) {
-      // 下方向への移動：currentIndex と newIndex の間の要素の高さの合計
       for (let i = currentIndex + 1; i <= newIndex; i++) {
         const itemElement = itemRefs.value[i]
-        if (itemElement) {
-          heightDiff += getElementTotalHeight(itemElement)
-        }
+        if (itemElement) heightDiff += getElementTotalHeight(itemElement)
       }
     } else {
-      // 上方向への移動：newIndex と currentIndex の間の要素の高さの合計（負の値）
       for (let i = newIndex; i < currentIndex; i++) {
         const itemElement = itemRefs.value[i]
-        if (itemElement) {
-          heightDiff -= getElementTotalHeight(itemElement)
-        }
+        if (itemElement) heightDiff -= getElementTotalHeight(itemElement)
       }
     }
-    
+
     const items = [...checklistItems.value]
     const [draggedItem] = items.splice(currentIndex, 1)
     items.splice(newIndex, 0, draggedItem)
     checklistItems.value = items
-    
-    // 新しい位置を基準に更新
+
     dragStartY.value = dragStartY.value + heightDiff
     dragItemIndex.value = newIndex
     dragOffsetY.value = dragCurrentY.value - dragStartY.value
   }
 }
 
-// タッチ終了
 const handleTouchEnd = () => {
-  // ドラッグ開始タイマーをクリア
   if (longPressTimer.value !== null) {
     window.clearTimeout(longPressTimer.value)
     longPressTimer.value = null
   }
-  
-  // ドラッグ中だった場合、並び順を保存
+
   if (isDragging.value) {
-    saveItemOrder()
+    saveItemOrderToLS()
+    scheduleSaveToFirestore()
   }
-  
-  // 状態をリセット
+
   draggingItemId.value = null
   isDragging.value = false
   dragItemIndex.value = -1
@@ -458,7 +487,6 @@ const handleTouchEnd = () => {
   dragOffsetY.value = 0
 }
 
-// タッチキャンセル
 const handleTouchCancel = () => {
   handleTouchEnd()
 }
@@ -471,39 +499,30 @@ const handleReset = () => {
     localStorage.removeItem(`${props.checklistId}-${item.id}`)
   })
   checkedItems.value = resetState
+  scheduleSaveToFirestore()
 }
 
-// 完了数を計算
-const completedCount = computed(() => 
+const completedCount = computed(() =>
   Object.values(checkedItems.value).filter(Boolean).length
 )
 const totalCount = computed(() => checklistItems.value.length)
-
-// isActiveのcomputed版を作成
 const isActiveComputed = computed(() => props.isActive)
 
-// 統計情報が変更されたときに親コンポーネントに通知
 watch([completedCount, totalCount, isActiveComputed], () => {
   if (props.isActive) {
     emit('update:stats', { completedCount: completedCount.value, totalCount: totalCount.value })
   }
 }, { immediate: true })
 
-// 編集モードを有効化
 const enableEditMode = () => {
   isEditMode.value = true
 }
 
-// 編集モードを無効化
 const disableEditMode = () => {
   isEditMode.value = false
-  // 編集中の項目があればキャンセル
-  if (editingItemId.value !== null) {
-    cancelEdit()
-  }
+  if (editingItemId.value !== null) cancelEdit()
 }
 
-// リセット機能と編集モード制御を外部に公開
 defineExpose({
   handleReset,
   enableEditMode,
@@ -518,8 +537,8 @@ defineExpose({
         v-for="(item, index) in checklistItems"
         :key="item.id"
         :ref="el => { itemRefs[index] = el ? (el as HTMLElement) : null }"
-        :class="['checklist-item', { 
-          checked: checkedItems[item.id], 
+        :class="['checklist-item', {
+          checked: checkedItems[item.id],
           editing: editingItemId === item.id,
           dragging: draggingItemId === item.id
         }]"
@@ -529,9 +548,9 @@ defineExpose({
         @touchend="handleTouchEnd"
         @touchcancel="handleTouchCancel"
       >
-        <label 
+        <label
           v-if="editingItemId !== item.id"
-          :for="item.id" 
+          :for="item.id"
           @click.prevent="!isEditMode && handleCheckChange(item.id)"
         >
           {{ getDisplayLabel(item) }}
@@ -566,7 +585,7 @@ defineExpose({
             </svg>
           </button>
         </div>
-        
+
         <div v-if="editingItemId === item.id" class="edit-mode">
           <input
             :ref="setEditInputRef"
@@ -634,12 +653,12 @@ defineExpose({
   border-radius: 10px;
   transition: all 0.3s ease;
   cursor: pointer;
-  touch-action: none; /* ブラウザのデフォルトタッチ動作を無効化 */
-  user-select: none; /* 長押し時のテキスト選択を防止 */
-  -webkit-user-select: none; /* Safari用 */
-  -moz-user-select: none; /* Firefox用 */
-  -webkit-touch-callout: none; /* iOS用：長押しメニューを無効化 */
-  -webkit-tap-highlight-color: transparent; /* タップ時のハイライトを無効化 */
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
   min-height: 46px;
   box-sizing: border-box;
 }
@@ -648,8 +667,7 @@ defineExpose({
   opacity: 0.9;
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
   z-index: 1000;
-  transition: none; /* ドラッグ中はトランジションを無効化 */
-  /* transformはインラインスタイルで動的に適用されます */
+  transition: none;
 }
 
 .checklist-item.checked {
@@ -694,8 +712,8 @@ defineExpose({
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
-  -webkit-touch-callout: none; /* iOS用：長押しメニューを無効化 */
-  -webkit-tap-highlight-color: transparent; /* タップ時のハイライトを無効化 */
+  -webkit-touch-callout: none;
+  -webkit-tap-highlight-color: transparent;
 }
 
 .checklist-item.editing {
@@ -822,7 +840,7 @@ defineExpose({
   border-radius: 5px;
   font-size: 1em;
   outline: none;
-  user-select: text; /* 編集時はテキスト選択を許可 */
+  user-select: text;
   -webkit-user-select: text;
   -moz-user-select: text;
   box-sizing: border-box;

--- a/src/components/LoginView.vue
+++ b/src/components/LoginView.vue
@@ -1,7 +1,61 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import { useAuth } from '../composables/useAuth'
 
-const { signInWithGoogle } = useAuth()
+const { signIn, signUp } = useAuth()
+
+const mode = ref<'login' | 'signup'>('login')
+const email = ref('')
+const password = ref('')
+const errorMessage = ref('')
+const isLoading = ref(false)
+
+const handleSubmit = async () => {
+  errorMessage.value = ''
+  if (!email.value || !password.value) {
+    errorMessage.value = 'メールアドレスとパスワードを入力してください'
+    return
+  }
+
+  isLoading.value = true
+  try {
+    if (mode.value === 'login') {
+      await signIn(email.value, password.value)
+    } else {
+      await signUp(email.value, password.value)
+    }
+  } catch (err: unknown) {
+    const error = err as { code?: string }
+    switch (error.code) {
+      case 'auth/invalid-email':
+        errorMessage.value = 'メールアドレスの形式が正しくありません'
+        break
+      case 'auth/user-not-found':
+      case 'auth/wrong-password':
+      case 'auth/invalid-credential':
+        errorMessage.value = 'メールアドレスまたはパスワードが正しくありません'
+        break
+      case 'auth/email-already-in-use':
+        errorMessage.value = 'このメールアドレスはすでに登録されています'
+        break
+      case 'auth/weak-password':
+        errorMessage.value = 'パスワードは6文字以上で入力してください'
+        break
+      case 'auth/too-many-requests':
+        errorMessage.value = 'ログイン試行が多すぎます。しばらくしてから再試行してください'
+        break
+      default:
+        errorMessage.value = 'エラーが発生しました。もう一度お試しください'
+    }
+  } finally {
+    isLoading.value = false
+  }
+}
+
+const toggleMode = () => {
+  mode.value = mode.value === 'login' ? 'signup' : 'login'
+  errorMessage.value = ''
+}
 </script>
 
 <template>
@@ -9,15 +63,51 @@ const { signInWithGoogle } = useAuth()
     <div class="login-card">
       <div class="login-icon">✅</div>
       <h1 class="login-title">チェックリスト</h1>
-      <p class="login-subtitle">ログインしてデバイス間でデータを同期</p>
-      <button class="google-button" @click="signInWithGoogle">
-        <svg class="google-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
-          <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
-          <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
-          <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
-        </svg>
-        Googleでログイン
+      <p class="login-subtitle">
+        {{ mode === 'login' ? 'ログインしてデータを同期' : '新規アカウントを作成' }}
+      </p>
+
+      <form class="login-form" @submit.prevent="handleSubmit">
+        <div class="field">
+          <label class="field-label" for="email">メールアドレス</label>
+          <input
+            id="email"
+            v-model="email"
+            type="email"
+            class="field-input"
+            placeholder="example@example.com"
+            autocomplete="email"
+            :disabled="isLoading"
+          />
+        </div>
+
+        <div class="field">
+          <label class="field-label" for="password">パスワード</label>
+          <input
+            id="password"
+            v-model="password"
+            type="password"
+            class="field-input"
+            :placeholder="mode === 'signup' ? '6文字以上' : 'パスワード'"
+            :autocomplete="mode === 'login' ? 'current-password' : 'new-password'"
+            :disabled="isLoading"
+          />
+        </div>
+
+        <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+
+        <button type="submit" class="submit-button" :disabled="isLoading">
+          <span v-if="isLoading" class="spinner"></span>
+          <span v-else>{{ mode === 'login' ? 'ログイン' : 'アカウントを作成' }}</span>
+        </button>
+      </form>
+
+      <button class="toggle-button" @click="toggleMode" :disabled="isLoading">
+        {{
+          mode === 'login'
+            ? 'アカウントをお持ちでない方はこちら'
+            : 'すでにアカウントをお持ちの方はこちら'
+        }}
       </button>
     </div>
   </div>
@@ -58,41 +148,115 @@ const { signInWithGoogle } = useAuth()
 .login-subtitle {
   color: #888;
   font-size: 0.95em;
-  margin: 0 0 36px;
+  margin: 0 0 28px;
 }
 
-.google-button {
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  text-align: left;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-label {
+  font-size: 0.85em;
+  font-weight: 600;
+  color: #555;
+}
+
+.field-input {
+  padding: 12px 14px;
+  border: 2px solid #e0e0e0;
+  border-radius: 10px;
+  font-size: 1em;
+  outline: none;
+  transition: border-color 0.2s ease;
+  background: white;
+}
+
+.field-input:focus {
+  border-color: #667eea;
+}
+
+.field-input:disabled {
+  background: #f5f5f5;
+  color: #aaa;
+}
+
+.error-message {
+  font-size: 0.88em;
+  color: #dc3545;
+  margin: 0;
+  text-align: center;
+}
+
+.submit-button {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
-  width: 100%;
-  padding: 14px 20px;
-  border: 2px solid #dadce0;
+  height: 50px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  border: none;
   border-radius: 12px;
-  background: white;
   font-size: 1em;
-  font-weight: 500;
-  color: #333;
+  font-weight: 600;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: opacity 0.2s ease, transform 0.1s ease;
   -webkit-tap-highlight-color: transparent;
+  margin-top: 4px;
 }
 
-.google-button:hover {
-  background: #f8f9ff;
-  border-color: #667eea;
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.2);
+.submit-button:hover:not(:disabled) {
+  opacity: 0.9;
 }
 
-.google-button:active {
+.submit-button:active:not(:disabled) {
   transform: scale(0.98);
 }
 
-.google-icon {
+.submit-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.spinner {
   width: 20px;
   height: 20px;
-  flex-shrink: 0;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.toggle-button {
+  display: block;
+  width: 100%;
+  margin-top: 20px;
+  background: none;
+  border: none;
+  color: #667eea;
+  font-size: 0.88em;
+  cursor: pointer;
+  text-align: center;
+  text-decoration: underline;
+  padding: 4px;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.toggle-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 @media (max-width: 480px) {

--- a/src/components/LoginView.vue
+++ b/src/components/LoginView.vue
@@ -1,0 +1,103 @@
+<script setup lang="ts">
+import { useAuth } from '../composables/useAuth'
+
+const { signInWithGoogle } = useAuth()
+</script>
+
+<template>
+  <div class="login-container">
+    <div class="login-card">
+      <div class="login-icon">✅</div>
+      <h1 class="login-title">チェックリスト</h1>
+      <p class="login-subtitle">ログインしてデバイス間でデータを同期</p>
+      <button class="google-button" @click="signInWithGoogle">
+        <svg class="google-icon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
+          <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+          <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+          <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+        </svg>
+        Googleでログイン
+      </button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.login-container {
+  height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  padding: 20px;
+}
+
+.login-card {
+  background: white;
+  border-radius: 20px;
+  padding: 48px 40px;
+  max-width: 400px;
+  width: 100%;
+  text-align: center;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.login-icon {
+  font-size: 3em;
+  margin-bottom: 16px;
+}
+
+.login-title {
+  font-size: 1.8em;
+  color: #333;
+  margin: 0 0 8px;
+  font-weight: 700;
+}
+
+.login-subtitle {
+  color: #888;
+  font-size: 0.95em;
+  margin: 0 0 36px;
+}
+
+.google-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  width: 100%;
+  padding: 14px 20px;
+  border: 2px solid #dadce0;
+  border-radius: 12px;
+  background: white;
+  font-size: 1em;
+  font-weight: 500;
+  color: #333;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.google-button:hover {
+  background: #f8f9ff;
+  border-color: #667eea;
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.2);
+}
+
+.google-button:active {
+  transform: scale(0.98);
+}
+
+.google-icon {
+  width: 20px;
+  height: 20px;
+  flex-shrink: 0;
+}
+
+@media (max-width: 480px) {
+  .login-card {
+    padding: 36px 24px;
+  }
+}
+</style>

--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, watch, nextTick } from 'vue'
+import type { User } from 'firebase/auth'
 
 // ナビゲーション項目の型定義
 export interface NavItem {
@@ -9,9 +10,10 @@ export interface NavItem {
 
 // Props定義
 interface Props {
-  activeItem: string  // 必須プロパティ：現在アクティブなチェックリストのID
+  activeItem: string
   navItems: NavItem[]
-  isEditMode?: boolean  // 編集モードかどうか
+  isEditMode?: boolean
+  user?: User | null
 }
 
 // Emits定義
@@ -19,10 +21,12 @@ interface Emits {
   (e: 'nav-change', id: string): void
   (e: 'add-checklist'): void
   (e: 'update-checklist-name', id: string, newName: string): void
+  (e: 'sign-out'): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
-  isEditMode: false
+  isEditMode: false,
+  user: null
 })
 
 const emit = defineEmits<Emits>()
@@ -110,6 +114,22 @@ watch(() => props.activeItem, async () => {
           title="新しいチェックリストを追加"
         >
           ＋
+        </button>
+        <button
+          v-if="props.user"
+          class="user-button"
+          @click="emit('sign-out')"
+          :title="`${props.user.displayName ?? props.user.email} としてログイン中 — タップしてサインアウト`"
+        >
+          <img
+            v-if="props.user.photoURL"
+            :src="props.user.photoURL"
+            :alt="props.user.displayName ?? 'user'"
+            class="user-avatar"
+          />
+          <span v-else class="user-avatar-fallback">
+            {{ (props.user.displayName ?? props.user.email ?? '?')[0].toUpperCase() }}
+          </span>
         </button>
       </template>
     </div>
@@ -208,6 +228,46 @@ watch(() => props.activeItem, async () => {
 .add-button:hover {
   background: #f0f3ff;
   transform: scale(1.05);
+}
+
+.user-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 4px;
+  background: none;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  flex-shrink: 0;
+  -webkit-tap-highlight-color: transparent;
+  transition: opacity 0.2s ease;
+}
+
+.user-button:hover {
+  opacity: 0.8;
+}
+
+.user-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid #667eea;
+}
+
+.user-avatar-fallback {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #667eea;
+  color: white;
+  font-size: 14px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #667eea;
 }
 
 .edit-name-container {

--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -2,13 +2,11 @@
 import { ref, watch, nextTick } from 'vue'
 import type { User } from 'firebase/auth'
 
-// ナビゲーション項目の型定義
 export interface NavItem {
   id: string
   label: string
 }
 
-// Props定義
 interface Props {
   activeItem: string
   navItems: NavItem[]
@@ -16,7 +14,6 @@ interface Props {
   user?: User | null
 }
 
-// Emits定義
 interface Emits {
   (e: 'nav-change', id: string): void
   (e: 'add-checklist'): void
@@ -31,25 +28,33 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<Emits>()
 
-// 編集中のテキスト
 const editingText = ref<string>('')
-// 入力フィールドへの参照
 const inputRef = ref<HTMLInputElement | null>(null)
+const isMenuOpen = ref(false)
 
-// ナビゲーション項目クリックハンドラー
 const handleNavClick = (id: string) => {
   emit('nav-change', id)
 }
 
-// チェックリスト追加ハンドラー
 const handleAddChecklist = () => {
   emit('add-checklist')
 }
 
-// 編集モードが変更されたときの処理
+const toggleMenu = () => {
+  isMenuOpen.value = !isMenuOpen.value
+}
+
+const closeMenu = () => {
+  isMenuOpen.value = false
+}
+
+const handleSignOut = () => {
+  isMenuOpen.value = false
+  emit('sign-out')
+}
+
 watch(() => props.isEditMode, async (newValue) => {
   if (newValue) {
-    // 編集モードに入ったら自動的に編集開始
     const activeNavItem = props.navItems.find(item => item.id === props.activeItem)
     if (activeNavItem) {
       editingText.value = activeNavItem.label
@@ -57,11 +62,9 @@ watch(() => props.isEditMode, async (newValue) => {
       inputRef.value?.focus()
     }
   } else {
-    // 編集モードを終了するときに変更を保存
     const trimmedText = editingText.value.trim()
     if (trimmedText) {
       const activeNavItem = props.navItems.find(item => item.id === props.activeItem)
-      // 元の名前と異なる場合のみ更新
       if (activeNavItem && trimmedText !== activeNavItem.label) {
         emit('update-checklist-name', props.activeItem, trimmedText)
       }
@@ -70,10 +73,8 @@ watch(() => props.isEditMode, async (newValue) => {
   }
 })
 
-// アクティブアイテムが変更されたときの処理
 watch(() => props.activeItem, async () => {
   if (props.isEditMode) {
-    // 編集モード中にアクティブアイテムが変更された場合、新しいアイテムの名前を設定
     const activeNavItem = props.navItems.find(item => item.id === props.activeItem)
     if (activeNavItem) {
       editingText.value = activeNavItem.label
@@ -100,37 +101,61 @@ watch(() => props.activeItem, async () => {
       </div>
       <!-- 通常のナビゲーションUI -->
       <template v-else>
-        <button
-          v-for="item in navItems"
-          :key="item.id"
-          :class="['nav-item', { active: props.activeItem === item.id }]"
-          @click="handleNavClick(item.id)"
-        >
-          <span class="nav-label">{{ item.label }}</span>
-        </button>
-        <button
-          class="add-button"
-          @click="handleAddChecklist"
-          title="新しいチェックリストを追加"
-        >
-          ＋
-        </button>
-        <button
-          v-if="props.user"
-          class="user-button"
-          @click="emit('sign-out')"
-          :title="`${props.user.displayName ?? props.user.email} としてログイン中 — タップしてサインアウト`"
-        >
-          <img
-            v-if="props.user.photoURL"
-            :src="props.user.photoURL"
-            :alt="props.user.displayName ?? 'user'"
-            class="user-avatar"
-          />
-          <span v-else class="user-avatar-fallback">
-            {{ (props.user.displayName ?? props.user.email ?? '?')[0].toUpperCase() }}
-          </span>
-        </button>
+        <!-- スクロール可能なナビ部分 -->
+        <div class="nav-items-scroll">
+          <button
+            v-for="item in navItems"
+            :key="item.id"
+            :class="['nav-item', { active: props.activeItem === item.id }]"
+            @click="handleNavClick(item.id)"
+          >
+            <span class="nav-label">{{ item.label }}</span>
+          </button>
+          <button
+            class="add-button"
+            @click="handleAddChecklist"
+            title="新しいチェックリストを追加"
+          >
+            ＋
+          </button>
+        </div>
+
+        <!-- 右端に固定表示するユーザーアイコン -->
+        <div v-if="props.user" class="user-area">
+          <button
+            class="user-button"
+            @click="toggleMenu"
+            :aria-expanded="isMenuOpen"
+            aria-label="ユーザーメニュー"
+          >
+            <img
+              v-if="props.user.photoURL"
+              :src="props.user.photoURL"
+              :alt="props.user.displayName ?? 'user'"
+              class="user-avatar"
+            />
+            <span v-else class="user-avatar-fallback">
+              {{ (props.user.displayName ?? props.user.email ?? '?')[0].toUpperCase() }}
+            </span>
+          </button>
+
+          <!-- サブメニュー -->
+          <Transition name="menu">
+            <div v-if="isMenuOpen" class="user-menu">
+              <div class="user-menu-id">{{ props.user.email ?? props.user.displayName }}</div>
+              <div class="user-menu-divider"></div>
+              <button class="user-menu-signout" @click="handleSignOut">
+                <svg xmlns="http://www.w3.org/2000/svg" height="18" viewBox="0 -960 960 960" width="18" fill="currentColor">
+                  <path d="M200-120q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h280v80H200v560h280v80H200Zm440-160-55-58 102-102H360v-80h327L585-622l55-58 200 200-200 200Z"/>
+                </svg>
+                ログアウト
+              </button>
+            </div>
+          </Transition>
+
+          <!-- メニュー外クリックで閉じる -->
+          <div v-if="isMenuOpen" class="menu-backdrop" @click="closeMenu"></div>
+        </div>
       </template>
     </div>
   </nav>
@@ -145,11 +170,8 @@ watch(() => props.activeItem, async () => {
   background: white;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
   z-index: 1000;
-  /* 視覚的な分離を強化するためのぼかし効果 */
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
-  /* ナビゲーションバーの高さをCSS変数として定義 */
-  /* 計算: top padding (6px) + safe area + content top padding (10px) + font height (14px) + content bottom padding (10px) + bottom padding (6px) = 45px */
   --nav-bar-height: calc(6px + env(safe-area-inset-top) + 10px + 14px + 10px + 6px);
 }
 
@@ -157,15 +179,23 @@ watch(() => props.activeItem, async () => {
   display: flex;
   align-items: center;
   padding: calc(6px + env(safe-area-inset-top)) 8px 6px;
-  overflow-x: auto;
-  gap: 8px;
-  /* スクロールバーを非表示にする */
-  scrollbar-width: none; /* Firefox */
-  -ms-overflow-style: none; /* IE and Edge */
+  gap: 0;
 }
 
-.nav-scroll-container::-webkit-scrollbar {
-  display: none; /* Chrome, Safari, Opera */
+/* スクロール可能なナビ部分 */
+.nav-items-scroll {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  overflow-x: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  min-width: 0;
+}
+
+.nav-items-scroll::-webkit-scrollbar {
+  display: none;
 }
 
 .nav-item {
@@ -182,11 +212,9 @@ watch(() => props.activeItem, async () => {
   border-radius: 10px;
   flex-shrink: 0;
   min-width: 100px;
-  /* 文字選択を無効化 */
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
-  /* 押下時のハイライトを無効化 */
   -webkit-tap-highlight-color: transparent;
 }
 
@@ -217,17 +245,22 @@ watch(() => props.activeItem, async () => {
   min-width: 60px;
   font-size: 20px;
   font-weight: bold;
-  /* 文字選択を無効化 */
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
-  /* 押下時のハイライトを無効化 */
   -webkit-tap-highlight-color: transparent;
 }
 
 .add-button:hover {
   background: #f0f3ff;
   transform: scale(1.05);
+}
+
+/* ユーザーエリア（右端固定） */
+.user-area {
+  position: relative;
+  flex-shrink: 0;
+  margin-left: 8px;
 }
 
 .user-button {
@@ -249,16 +282,16 @@ watch(() => props.activeItem, async () => {
 }
 
 .user-avatar {
-  width: 28px;
-  height: 28px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
   object-fit: cover;
   border: 2px solid #667eea;
 }
 
 .user-avatar-fallback {
-  width: 28px;
-  height: 28px;
+  width: 30px;
+  height: 30px;
   border-radius: 50%;
   background: #667eea;
   color: white;
@@ -268,6 +301,72 @@ watch(() => props.activeItem, async () => {
   align-items: center;
   justify-content: center;
   border: 2px solid #667eea;
+}
+
+/* サブメニュー */
+.user-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
+  min-width: 200px;
+  overflow: hidden;
+  z-index: 2000;
+}
+
+.user-menu-id {
+  padding: 14px 16px 10px;
+  font-size: 0.82em;
+  color: #888;
+  word-break: break-all;
+  line-height: 1.4;
+}
+
+.user-menu-divider {
+  height: 1px;
+  background: #f0f0f0;
+  margin: 0;
+}
+
+.user-menu-signout {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  font-size: 0.95em;
+  color: #dc3545;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.user-menu-signout:hover {
+  background: #fff5f5;
+}
+
+/* メニュー外クリック検知用オーバーレイ */
+.menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1999;
+}
+
+/* メニューのアニメーション */
+.menu-enter-active,
+.menu-leave-active {
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.menu-enter-from,
+.menu-leave-to {
+  opacity: 0;
+  transform: translateY(-6px);
 }
 
 .edit-name-container {
@@ -295,14 +394,11 @@ watch(() => props.activeItem, async () => {
 
 @media (max-width: 600px) {
   .navigation-bar {
-    /* スマートフォン用のナビゲーションバーの高さ */
-    /* 計算: top padding (6px) + safe area + content top padding (8px) + font height (13px) + content bottom padding (8px) + bottom padding (6px) = 41px */
     --nav-bar-height: calc(6px + env(safe-area-inset-top) + 8px + 13px + 8px + 6px);
   }
 
   .nav-scroll-container {
     padding: calc(6px + env(safe-area-inset-top)) 6px 6px;
-    gap: 6px;
   }
 
   .nav-item {
@@ -313,7 +409,7 @@ watch(() => props.activeItem, async () => {
   .nav-label {
     font-size: 13px;
   }
-  
+
   .add-button {
     padding: 2px 12px;
     min-width: 50px;

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -1,9 +1,7 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import {
-  GoogleAuthProvider,
-  signInWithRedirect,
-  signInWithPopup,
-  getRedirectResult,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
   signOut as firebaseSignOut,
   onAuthStateChanged,
   type User
@@ -13,7 +11,6 @@ import { auth } from '../firebase/index'
 const user = ref<User | null>(null)
 const authLoading = ref(true)
 
-// シングルトンとして認証状態を管理
 let unsubscribe: (() => void) | null = null
 let listenerCount = 0
 
@@ -21,20 +18,10 @@ export function useAuth() {
   onMounted(() => {
     listenerCount++
     if (!unsubscribe) {
-      // リダイレクト後の認証結果を取得
-      getRedirectResult(auth).catch(() => {
-        // リダイレクトではない場合は無視
-      })
-
       unsubscribe = onAuthStateChanged(auth, (u) => {
         user.value = u
         authLoading.value = false
       })
-    } else {
-      // すでにリスナーが設定済みの場合、ローディングを解除
-      if (user.value !== undefined) {
-        authLoading.value = false
-      }
     }
   })
 
@@ -46,26 +33,13 @@ export function useAuth() {
     }
   })
 
-  const signInWithGoogle = async () => {
-    const provider = new GoogleAuthProvider()
-    // iOS PWA などポップアップが使えない環境ではリダイレクトにフォールバック
-    try {
-      await signInWithPopup(auth, provider)
-    } catch (err: unknown) {
-      const error = err as { code?: string }
-      if (
-        error.code === 'auth/popup-blocked' ||
-        error.code === 'auth/popup-closed-by-user' ||
-        error.code === 'auth/cancelled-popup-request'
-      ) {
-        await signInWithRedirect(auth, provider)
-      } else {
-        throw err
-      }
-    }
-  }
+  const signIn = (email: string, password: string) =>
+    signInWithEmailAndPassword(auth, email, password)
+
+  const signUp = (email: string, password: string) =>
+    createUserWithEmailAndPassword(auth, email, password)
 
   const signOut = () => firebaseSignOut(auth)
 
-  return { user, authLoading, signInWithGoogle, signOut }
+  return { user, authLoading, signIn, signUp, signOut }
 }

--- a/src/composables/useAuth.ts
+++ b/src/composables/useAuth.ts
@@ -1,0 +1,71 @@
+import { ref, onMounted, onUnmounted } from 'vue'
+import {
+  GoogleAuthProvider,
+  signInWithRedirect,
+  signInWithPopup,
+  getRedirectResult,
+  signOut as firebaseSignOut,
+  onAuthStateChanged,
+  type User
+} from 'firebase/auth'
+import { auth } from '../firebase/index'
+
+const user = ref<User | null>(null)
+const authLoading = ref(true)
+
+// シングルトンとして認証状態を管理
+let unsubscribe: (() => void) | null = null
+let listenerCount = 0
+
+export function useAuth() {
+  onMounted(() => {
+    listenerCount++
+    if (!unsubscribe) {
+      // リダイレクト後の認証結果を取得
+      getRedirectResult(auth).catch(() => {
+        // リダイレクトではない場合は無視
+      })
+
+      unsubscribe = onAuthStateChanged(auth, (u) => {
+        user.value = u
+        authLoading.value = false
+      })
+    } else {
+      // すでにリスナーが設定済みの場合、ローディングを解除
+      if (user.value !== undefined) {
+        authLoading.value = false
+      }
+    }
+  })
+
+  onUnmounted(() => {
+    listenerCount--
+    if (listenerCount === 0 && unsubscribe) {
+      unsubscribe()
+      unsubscribe = null
+    }
+  })
+
+  const signInWithGoogle = async () => {
+    const provider = new GoogleAuthProvider()
+    // iOS PWA などポップアップが使えない環境ではリダイレクトにフォールバック
+    try {
+      await signInWithPopup(auth, provider)
+    } catch (err: unknown) {
+      const error = err as { code?: string }
+      if (
+        error.code === 'auth/popup-blocked' ||
+        error.code === 'auth/popup-closed-by-user' ||
+        error.code === 'auth/cancelled-popup-request'
+      ) {
+        await signInWithRedirect(auth, provider)
+      } else {
+        throw err
+      }
+    }
+  }
+
+  const signOut = () => firebaseSignOut(auth)
+
+  return { user, authLoading, signInWithGoogle, signOut }
+}

--- a/src/firebase/firestore.ts
+++ b/src/firebase/firestore.ts
@@ -1,0 +1,100 @@
+import {
+  doc,
+  getDoc,
+  setDoc,
+  deleteDoc,
+  onSnapshot,
+  type Unsubscribe
+} from 'firebase/firestore'
+import { db } from './index'
+
+export interface ChecklistItem {
+  id: string
+  label: string
+}
+
+export interface ChecklistConfig {
+  id: string
+  label: string
+  initialItems: ChecklistItem[]
+}
+
+export interface ChecklistData {
+  customItems: ChecklistItem[]
+  order: string[]
+  checkedItems: Record<string, boolean>
+  customLabels: Record<string, string>
+}
+
+// ユーザーのチェックリスト設定を取得
+export async function loadChecklistsConfig(uid: string): Promise<ChecklistConfig[] | null> {
+  const ref = doc(db, 'users', uid, 'data', 'config')
+  const snap = await getDoc(ref)
+  if (snap.exists()) {
+    return snap.data().checklists as ChecklistConfig[]
+  }
+  return null
+}
+
+// ユーザーのチェックリスト設定をリアルタイム購読
+export function subscribeChecklistsConfig(
+  uid: string,
+  callback: (checklists: ChecklistConfig[] | null) => void
+): Unsubscribe {
+  const ref = doc(db, 'users', uid, 'data', 'config')
+  return onSnapshot(ref, (snap) => {
+    if (snap.exists()) {
+      callback(snap.data().checklists as ChecklistConfig[])
+    } else {
+      callback(null)
+    }
+  })
+}
+
+// ユーザーのチェックリスト設定を保存
+export async function saveChecklistsConfig(uid: string, checklists: ChecklistConfig[]): Promise<void> {
+  const ref = doc(db, 'users', uid, 'data', 'config')
+  await setDoc(ref, { checklists })
+}
+
+// チェックリストデータを取得
+export async function loadChecklistData(uid: string, checklistId: string): Promise<ChecklistData | null> {
+  const ref = doc(db, 'users', uid, 'checklists', checklistId)
+  const snap = await getDoc(ref)
+  if (snap.exists()) {
+    return snap.data() as ChecklistData
+  }
+  return null
+}
+
+// チェックリストデータをリアルタイム購読
+export function subscribeChecklistData(
+  uid: string,
+  checklistId: string,
+  callback: (data: ChecklistData | null) => void
+): Unsubscribe {
+  const ref = doc(db, 'users', uid, 'checklists', checklistId)
+  return onSnapshot(ref, (snap) => {
+    if (snap.exists()) {
+      callback(snap.data() as ChecklistData)
+    } else {
+      callback(null)
+    }
+  })
+}
+
+// チェックリストデータを保存
+export async function saveChecklistData(
+  uid: string,
+  checklistId: string,
+  data: ChecklistData
+): Promise<void> {
+  const ref = doc(db, 'users', uid, 'checklists', checklistId)
+  await setDoc(ref, data)
+}
+
+// チェックリストデータを削除
+export async function deleteChecklistData(uid: string, checklistId: string): Promise<void> {
+  const ref = doc(db, 'users', uid, 'checklists', checklistId)
+  await deleteDoc(ref)
+}

--- a/src/firebase/index.ts
+++ b/src/firebase/index.ts
@@ -1,0 +1,16 @@
+import { initializeApp } from 'firebase/app'
+import { getAuth } from 'firebase/auth'
+import { getFirestore } from 'firebase/firestore'
+
+const firebaseConfig = {
+  apiKey: 'AIzaSyD-ZqqmjWn1LSxII6BeVqbbWoJITlSv7HQ',
+  authDomain: 'check-list-f5aee.firebaseapp.com',
+  projectId: 'check-list-f5aee',
+  storageBucket: 'check-list-f5aee.firebasestorage.app',
+  messagingSenderId: '766444919460',
+  appId: '1:766444919460:web:a36a1765bddbfd107ce431'
+}
+
+const app = initializeApp(firebaseConfig)
+export const auth = getAuth(app)
+export const db = getFirestore(app)

--- a/tsconfig.tsbuildinfo
+++ b/tsconfig.tsbuildinfo
@@ -1,1 +1,1 @@
-{"root":["./src/env.d.ts","./src/main.ts","./src/App.vue","./src/components/GenericChecklist.vue","./src/components/NavigationBar.vue"],"version":"5.9.3"}
+{"root":["./src/env.d.ts","./src/main.ts","./src/composables/useAuth.ts","./src/firebase/firestore.ts","./src/firebase/index.ts","./src/App.vue","./src/components/GenericChecklist.vue","./src/components/LoginView.vue","./src/components/NavigationBar.vue"],"version":"5.9.3"}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Google認証**によるログイン/サインアウト機能を追加（ポップアップ→リダイレクトフォールバック対応）
- **Firestore リアルタイム同期**でチェックリストの設定・項目・チェック状態・並び順をデバイス間同期
- 未ログイン時は既存の **LocalStorage** をフォールバックとして使用、動作を維持
- ログイン初回時にLocalStorageのデータをFirestoreへ自動移行

## 新規ファイル

| ファイル | 役割 |
|---|---|
| `src/firebase/index.ts` | Firebase アプリ初期化（Auth / Firestore） |
| `src/firebase/firestore.ts` | Firestore の読み書き・リアルタイム購読ヘルパー |
| `src/composables/useAuth.ts` | 認証状態管理コンポーザブル |
| `src/components/LoginView.vue` | Google ログイン画面 |

## 変更ファイル

- **App.vue** — 認証状態に応じてLoginView表示、Firestoreでchecklists config同期
- **GenericChecklist.vue** — `uid` propを追加、Firestore購読でアイテムデータを同期
- **NavigationBar.vue** — ユーザーアバター表示とサインアウトボタンを追加

## Firestoreデータ構造

```
users/{uid}/data/config   → { checklists: ChecklistConfig[] }
users/{uid}/checklists/{checklistId} → { customItems, order, checkedItems, customLabels }
```

## Test plan

- [ ] 未ログイン状態でログイン画面が表示される
- [ ] Googleアカウントでログインできる
- [ ] ログイン後、既存のLocalStorageデータがFirestoreに移行される
- [ ] チェックのON/OFFがFirestoreに保存・同期される
- [ ] 項目の追加・削除・並び替えがFirestoreに反映される
- [ ] チェックリストの追加・削除がFirestoreに反映される
- [ ] ナビゲーションバーにアバターが表示され、タップでサインアウトできる
- [ ] サインアウト後にログイン画面に戻る

https://claude.ai/code/session_01QaGuJbXEANsT6p6AdkMjNe
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QaGuJbXEANsT6p6AdkMjNe)_