### PR TITLE
フッターの要素をヘッダーに移動し、フッターを廃止

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,6 +14,9 @@ import type { Unsubscribe } from 'firebase/firestore'
 
 const { user, authLoading, signOut } = useAuth()
 
+const navBarEl = ref<InstanceType<typeof NavigationBar> | null>(null)
+let navBarObserver: ResizeObserver | null = null
+
 // デフォルトのチェックリスト設定
 const defaultChecklists: ChecklistConfig[] = [
   {
@@ -152,29 +155,28 @@ watch(checklists, () => {
   }
 }, { deep: true })
 
-const bottomBarEl = ref<HTMLElement | null>(null)
-let bottomBarObserver: ResizeObserver | null = null
-
-onMounted(() => {
-  loadFromLocalStorage()
-
-  if (bottomBarEl.value) {
-    const applyHeight = () => {
-      if (bottomBarEl.value) {
-        document.documentElement.style.setProperty(
-          '--bottom-bar-height',
-          `${bottomBarEl.value.offsetHeight}px`
-        )
-      }
+watch(navBarEl, (el) => {
+  navBarObserver?.disconnect()
+  navBarObserver = null
+  if (el?.$el) {
+    const applyNavHeight = () => {
+      document.documentElement.style.setProperty(
+        '--nav-bar-height',
+        `${(el.$el as HTMLElement).offsetHeight}px`
+      )
     }
-    applyHeight()
-    bottomBarObserver = new ResizeObserver(applyHeight)
-    bottomBarObserver.observe(bottomBarEl.value)
+    applyNavHeight()
+    navBarObserver = new ResizeObserver(applyNavHeight)
+    navBarObserver.observe(el.$el as HTMLElement)
   }
 })
 
+onMounted(() => {
+  loadFromLocalStorage()
+})
+
 onBeforeUnmount(() => {
-  bottomBarObserver?.disconnect()
+  navBarObserver?.disconnect()
   stopFirestoreSync()
 })
 
@@ -403,14 +405,18 @@ const handleTouchEnd = () => {
     @touchend="handleTouchEnd"
   >
     <NavigationBar
+      ref="navBarEl"
       :active-item="activeView"
       :nav-items="navItems"
       :is-edit-mode="isEditMode"
       :user="user"
+      :stats="stats"
       @nav-change="handleNavChangeWithEditReset"
       @add-checklist="handleAddChecklist"
       @update-checklist-name="handleUpdateChecklistName"
       @sign-out="signOut"
+      @edit="handleEdit"
+      @reset-or-delete="handleResetOrDelete"
     />
     <div class="view-container">
       <div
@@ -434,26 +440,6 @@ const handleTouchEnd = () => {
             @update:stats="handleStatsUpdate"
           />
         </div>
-      </div>
-    </div>
-    <div class="bottom-bar" ref="bottomBarEl">
-      <div class="progress">
-        {{ stats.completedCount }} / {{ stats.totalCount }} 完了
-      </div>
-      <div class="button-group">
-        <button
-          class="edit-button"
-          :class="{ active: isEditMode }"
-          @click="handleEdit"
-        >
-          {{ isEditMode ? '編集完了' : '項目を編集' }}
-        </button>
-        <button
-          :class="isEditMode ? 'delete-list-button' : 'reset-button'"
-          @click="handleResetOrDelete"
-        >
-          {{ isEditMode ? 'リストを削除' : 'すべてリセット' }}
-        </button>
       </div>
     </div>
   </div>
@@ -489,13 +475,12 @@ const handleTouchEnd = () => {
   overflow-x: hidden;
   touch-action: pan-y;
   position: relative;
-  --nav-bar-height: calc(6px + env(safe-area-inset-top) + 10px + 14px + 10px + 6px);
 }
 
 .view-container {
   position: absolute;
   top: var(--nav-bar-height);
-  bottom: var(--bottom-bar-height, 100px);
+  bottom: 0;
   left: 0;
   right: 0;
   display: flex;
@@ -526,112 +511,8 @@ const handleTouchEnd = () => {
 }
 
 @media (max-width: 600px) {
-  .app {
-    --nav-bar-height: calc(6px + env(safe-area-inset-top) + 8px + 13px + 8px + 6px);
-  }
-
   .view-wrapper {
     padding: 0;
-  }
-}
-
-.bottom-bar {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background: white;
-  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.15);
-  padding: 15px 20px calc(15px + env(safe-area-inset-bottom, 0px));
-  z-index: 1001;
-}
-
-.progress {
-  text-align: center;
-  font-size: 1.2em;
-  color: #667eea;
-  font-weight: bold;
-  margin-bottom: 10px;
-}
-
-.button-group {
-  display: flex;
-  gap: 10px;
-}
-
-.edit-button,
-.reset-button {
-  flex: 1;
-  padding: 15px;
-  border: none;
-  border-radius: 10px;
-  font-size: 1.1em;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  user-select: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -webkit-tap-highlight-color: transparent;
-}
-
-.edit-button {
-  background: #f0f0f0;
-  color: #667eea;
-  border: 2px solid #667eea;
-}
-
-.edit-button:hover {
-  background: #e0e0f0;
-}
-
-.edit-button.active {
-  background: #667eea;
-  color: white;
-}
-
-.reset-button {
-  background: #667eea;
-  color: white;
-}
-
-.delete-list-button {
-  flex: 1;
-  padding: 15px;
-  border: none;
-  border-radius: 10px;
-  font-size: 1.1em;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  background: #dc3545;
-  color: white;
-  user-select: none;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -webkit-tap-highlight-color: transparent;
-}
-
-.delete-list-button:hover {
-  background: #c82333;
-}
-
-@media (max-width: 600px) {
-  .bottom-bar {
-    padding: 12px 16px calc(12px + env(safe-area-inset-bottom, 0px));
-  }
-
-  .edit-button,
-  .reset-button,
-  .delete-list-button {
-    padding: 12px;
-  }
-
-  .progress {
-    font-size: 1.1em;
-    margin-bottom: 8px;
-  }
-
-  .button-group {
-    gap: 8px;
   }
 }
 </style>

--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -99,26 +99,6 @@ watch(() => props.activeItem, async () => {
 
 <template>
   <nav class="navigation-bar">
-    <div class="action-bar">
-      <div class="progress">
-        {{ props.stats.completedCount }} / {{ props.stats.totalCount }} 完了
-      </div>
-      <div class="button-group">
-        <button
-          class="edit-button"
-          :class="{ active: props.isEditMode }"
-          @click="handleEdit"
-        >
-          {{ props.isEditMode ? '編集完了' : '項目を編集' }}
-        </button>
-        <button
-          :class="props.isEditMode ? 'delete-list-button' : 'reset-button'"
-          @click="handleResetOrDelete"
-        >
-          {{ props.isEditMode ? 'リストを削除' : 'すべてリセット' }}
-        </button>
-      </div>
-    </div>
     <div class="nav-scroll-container">
       <!-- 編集モードの場合は入力フィールドを表示 -->
       <div v-if="props.isEditMode" class="edit-name-container">
@@ -190,6 +170,26 @@ watch(() => props.activeItem, async () => {
         </div>
       </template>
     </div>
+    <div class="action-bar">
+      <div class="progress">
+        {{ props.stats.completedCount }} / {{ props.stats.totalCount }} 完了
+      </div>
+      <div class="button-group">
+        <button
+          class="edit-button"
+          :class="{ active: props.isEditMode }"
+          @click="handleEdit"
+        >
+          {{ props.isEditMode ? '編集完了' : '項目を編集' }}
+        </button>
+        <button
+          :class="props.isEditMode ? 'delete-list-button' : 'reset-button'"
+          @click="handleResetOrDelete"
+        >
+          {{ props.isEditMode ? 'リストを削除' : 'すべてリセット' }}
+        </button>
+      </div>
+    </div>
   </nav>
 </template>
 
@@ -208,8 +208,8 @@ watch(() => props.activeItem, async () => {
 }
 
 .action-bar {
-  padding: 15px 20px 10px;
-  border-bottom: 1px solid #f0f0f0;
+  padding: 10px 20px 15px;
+  border-top: 1px solid #f0f0f0;
 }
 
 .progress {
@@ -499,7 +499,7 @@ watch(() => props.activeItem, async () => {
 
 @media (max-width: 600px) {
   .action-bar {
-    padding: 12px 16px 8px;
+    padding: 8px 16px 12px;
   }
 
   .nav-scroll-container {

--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -208,42 +208,47 @@ watch(() => props.activeItem, async () => {
 }
 
 .action-bar {
-  padding: 10px 20px 15px;
+  padding: 8px 20px 12px;
   border-top: 1px solid #f0f0f0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
 .progress {
-  text-align: center;
-  font-size: 1.2em;
+  font-size: 0.95em;
   color: #667eea;
   font-weight: bold;
-  margin-bottom: 10px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .button-group {
   display: flex;
-  gap: 10px;
+  gap: 8px;
+  flex: 1;
+  justify-content: flex-end;
 }
 
 .edit-button,
 .reset-button {
-  flex: 1;
-  padding: 15px;
+  padding: 6px 12px;
   border: none;
-  border-radius: 10px;
-  font-size: 1.1em;
+  border-radius: 8px;
+  font-size: 0.85em;
   cursor: pointer;
   transition: all 0.3s ease;
   user-select: none;
   -webkit-user-select: none;
   -moz-user-select: none;
   -webkit-tap-highlight-color: transparent;
+  white-space: nowrap;
 }
 
 .edit-button {
   background: #f0f0f0;
   color: #667eea;
-  border: 2px solid #667eea;
+  border: 1.5px solid #667eea;
 }
 
 .edit-button:hover {
@@ -261,11 +266,10 @@ watch(() => props.activeItem, async () => {
 }
 
 .delete-list-button {
-  flex: 1;
-  padding: 15px;
+  padding: 6px 12px;
   border: none;
-  border-radius: 10px;
-  font-size: 1.1em;
+  border-radius: 8px;
+  font-size: 0.85em;
   cursor: pointer;
   transition: all 0.3s ease;
   background: #dc3545;
@@ -274,6 +278,7 @@ watch(() => props.activeItem, async () => {
   -webkit-user-select: none;
   -moz-user-select: none;
   -webkit-tap-highlight-color: transparent;
+  white-space: nowrap;
 }
 
 .delete-list-button:hover {
@@ -529,17 +534,16 @@ watch(() => props.activeItem, async () => {
   .edit-button,
   .reset-button,
   .delete-list-button {
-    padding: 12px;
-    font-size: 1em;
+    padding: 5px 10px;
+    font-size: 0.8em;
   }
 
   .progress {
-    font-size: 1.1em;
-    margin-bottom: 8px;
+    font-size: 0.9em;
   }
 
   .button-group {
-    gap: 8px;
+    gap: 6px;
   }
 }
 </style>

--- a/src/components/NavigationBar.vue
+++ b/src/components/NavigationBar.vue
@@ -12,6 +12,7 @@ interface Props {
   navItems: NavItem[]
   isEditMode?: boolean
   user?: User | null
+  stats?: { completedCount: number; totalCount: number }
 }
 
 interface Emits {
@@ -19,11 +20,14 @@ interface Emits {
   (e: 'add-checklist'): void
   (e: 'update-checklist-name', id: string, newName: string): void
   (e: 'sign-out'): void
+  (e: 'edit'): void
+  (e: 'reset-or-delete'): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
   isEditMode: false,
-  user: null
+  user: null,
+  stats: () => ({ completedCount: 0, totalCount: 0 })
 })
 
 const emit = defineEmits<Emits>()
@@ -51,6 +55,14 @@ const closeMenu = () => {
 const handleSignOut = () => {
   isMenuOpen.value = false
   emit('sign-out')
+}
+
+const handleEdit = () => {
+  emit('edit')
+}
+
+const handleResetOrDelete = () => {
+  emit('reset-or-delete')
 }
 
 watch(() => props.isEditMode, async (newValue) => {
@@ -87,6 +99,26 @@ watch(() => props.activeItem, async () => {
 
 <template>
   <nav class="navigation-bar">
+    <div class="action-bar">
+      <div class="progress">
+        {{ props.stats.completedCount }} / {{ props.stats.totalCount }} 完了
+      </div>
+      <div class="button-group">
+        <button
+          class="edit-button"
+          :class="{ active: props.isEditMode }"
+          @click="handleEdit"
+        >
+          {{ props.isEditMode ? '編集完了' : '項目を編集' }}
+        </button>
+        <button
+          :class="props.isEditMode ? 'delete-list-button' : 'reset-button'"
+          @click="handleResetOrDelete"
+        >
+          {{ props.isEditMode ? 'リストを削除' : 'すべてリセット' }}
+        </button>
+      </div>
+    </div>
     <div class="nav-scroll-container">
       <!-- 編集モードの場合は入力フィールドを表示 -->
       <div v-if="props.isEditMode" class="edit-name-container">
@@ -161,6 +193,7 @@ watch(() => props.activeItem, async () => {
   </nav>
 </template>
 
+
 <style scoped>
 .navigation-bar {
   position: fixed;
@@ -172,7 +205,79 @@ watch(() => props.activeItem, async () => {
   z-index: 1000;
   -webkit-backdrop-filter: blur(10px);
   backdrop-filter: blur(10px);
-  --nav-bar-height: calc(6px + env(safe-area-inset-top) + 10px + 14px + 10px + 6px);
+}
+
+.action-bar {
+  padding: 15px 20px 10px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.progress {
+  text-align: center;
+  font-size: 1.2em;
+  color: #667eea;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.button-group {
+  display: flex;
+  gap: 10px;
+}
+
+.edit-button,
+.reset-button {
+  flex: 1;
+  padding: 15px;
+  border: none;
+  border-radius: 10px;
+  font-size: 1.1em;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.edit-button {
+  background: #f0f0f0;
+  color: #667eea;
+  border: 2px solid #667eea;
+}
+
+.edit-button:hover {
+  background: #e0e0f0;
+}
+
+.edit-button.active {
+  background: #667eea;
+  color: white;
+}
+
+.reset-button {
+  background: #667eea;
+  color: white;
+}
+
+.delete-list-button {
+  flex: 1;
+  padding: 15px;
+  border: none;
+  border-radius: 10px;
+  font-size: 1.1em;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  background: #dc3545;
+  color: white;
+  user-select: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.delete-list-button:hover {
+  background: #c82333;
 }
 
 .nav-scroll-container {
@@ -393,8 +498,8 @@ watch(() => props.activeItem, async () => {
 }
 
 @media (max-width: 600px) {
-  .navigation-bar {
-    --nav-bar-height: calc(6px + env(safe-area-inset-top) + 8px + 13px + 8px + 6px);
+  .action-bar {
+    padding: 12px 16px 8px;
   }
 
   .nav-scroll-container {
@@ -419,6 +524,22 @@ watch(() => props.activeItem, async () => {
     font-size: 13px;
     padding: 6px 10px;
     min-width: 120px;
+  }
+
+  .edit-button,
+  .reset-button,
+  .delete-list-button {
+    padding: 12px;
+    font-size: 1em;
+  }
+
+  .progress {
+    font-size: 1.1em;
+    margin-bottom: 8px;
+  }
+
+  .button-group {
+    gap: 8px;
   }
 }
 </style>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- フッター (`bottom-bar`) に表示していた「進捗表示」「項目を編集」「すべてリセット/リストを削除」ボタンを `NavigationBar` の上部 (`action-bar`) に移動
- フッター関連の DOM・CSS スタイル・ResizeObserver を `App.vue` から削除
- `NavigationBar` の実際の高さを ResizeObserver で動的に計測し、`:root` の `--nav-bar-height` CSS 変数を更新することで、コンテンツ領域の上端オフセットを正確に保つ

## Test plan

- [ ] ログイン後、ヘッダーに進捗表示・編集ボタン・リセットボタンが表示されることを確認
- [ ] 「項目を編集」ボタンで編集モードへの切り替えが動作すること
- [ ] 編集モード中「リストを削除」ボタンでチェックリストが削除されること
- [ ] 「すべてリセット」でチェックが解除されること
- [ ] チェックリスト一覧のタブナビゲーションが正常に動作すること
- [ ] モバイル表示（600px 以下）でレイアウトが崩れないこと
- [ ] フッターが表示されないことを確認

https://claude.ai/code/session_01QmxbiKy2vAihGLh1u4AXKP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmxbiKy2vAihGLh1u4AXKP)_