### PR TITLE
初期項目の削除を永続化し、削除ダイアログを統一する

### DIFF
--- a/src/components/GenericChecklist.vue
+++ b/src/components/GenericChecklist.vue
@@ -77,8 +77,23 @@ const saveCustomItemsToLS = (items: ChecklistItem[]) => {
   localStorage.setItem(`${props.checklistId}-custom-items`, JSON.stringify(items))
 }
 
+const deletedInitialIds = ref<string[]>([])
+
+const loadDeletedInitialIdsFromLS = () => {
+  const saved = localStorage.getItem(`${props.checklistId}-deleted-initial-ids`)
+  if (saved) {
+    try { deletedInitialIds.value = JSON.parse(saved) } catch { deletedInitialIds.value = [] }
+  }
+}
+
+const saveDeletedInitialIdsToLS = (ids: string[]) => {
+  localStorage.setItem(`${props.checklistId}-deleted-initial-ids`, JSON.stringify(ids))
+}
+
 const getAllItems = (): ChecklistItem[] => {
-  return [...props.initialItems, ...loadCustomItemsFromLS()]
+  const deletedSet = new Set(deletedInitialIds.value)
+  const activeInitialItems = props.initialItems.filter(i => !deletedSet.has(i.id))
+  return [...activeInitialItems, ...loadCustomItemsFromLS()]
 }
 
 const loadItemOrderFromLS = () => {
@@ -131,14 +146,14 @@ const loadCustomLabelsFromLS = () => {
 
 // 現在の状態を ChecklistData にまとめる
 const buildChecklistData = (): ChecklistData => {
-  // customItems = checklistItems のうち initialItems に含まれないもの
   const initialIds = new Set(props.initialItems.map(i => i.id))
   const customItems = checklistItems.value.filter(i => !initialIds.has(i.id))
   return {
     customItems,
     order: checklistItems.value.map(i => i.id),
     checkedItems: { ...checkedItems.value },
-    customLabels: { ...customLabels.value }
+    customLabels: { ...customLabels.value },
+    deletedInitialIds: [...deletedInitialIds.value]
   }
 }
 
@@ -166,13 +181,19 @@ const scheduleSaveToFirestore = () => {
 
 // Firestoreのデータを状態に適用
 const applyFirestoreData = (data: ChecklistData) => {
-  const allInitialItems = [...props.initialItems]
+  if (data.deletedInitialIds) {
+    deletedInitialIds.value = [...data.deletedInitialIds]
+    saveDeletedInitialIdsToLS(deletedInitialIds.value)
+  }
+
+  const deletedSet = new Set(deletedInitialIds.value)
+  const activeInitialItems = props.initialItems.filter(i => !deletedSet.has(i.id))
   const customItemMap = new Map(data.customItems.map(i => [i.id, i]))
 
   // order に従って並べ替え
   const allItems: ChecklistItem[] = []
   data.order.forEach(id => {
-    const initial = allInitialItems.find(i => i.id === id)
+    const initial = activeInitialItems.find(i => i.id === id)
     if (initial) {
       allItems.push(initial)
     } else if (customItemMap.has(id)) {
@@ -180,7 +201,7 @@ const applyFirestoreData = (data: ChecklistData) => {
     }
   })
   // order に含まれていないものを末尾に追加
-  allInitialItems.forEach(i => {
+  activeInitialItems.forEach(i => {
     if (!data.order.includes(i.id)) allItems.push(i)
   })
   data.customItems.forEach(i => {
@@ -238,6 +259,7 @@ watch(() => props.uid, (newUid) => {
 
 // コンポーネントマウント時に状態を読み込む
 onMounted(() => {
+  loadDeletedInitialIdsFromLS()
   loadItemOrderFromLS()
   loadCheckedStateFromLS()
   loadCustomLabelsFromLS()
@@ -333,16 +355,17 @@ const addNewItem = async () => {
 
 // アイテムを削除
 const deleteItem = (id: string) => {
+  if (!confirm('この項目を削除しますか？')) return
+
   const isInitialItem = props.initialItems.some(item => item.id === id)
-  if (isInitialItem) {
-    if (!confirm('初期項目を削除しますか？\n（削除しても初期項目は再読み込み時に復元できます）')) return
-  } else {
-    if (!confirm('この項目を削除しますか？')) return
-  }
 
   checklistItems.value = checklistItems.value.filter(item => item.id !== id)
 
-  if (!isInitialItem) {
+  if (isInitialItem) {
+    const newDeletedIds = [...deletedInitialIds.value, id]
+    deletedInitialIds.value = newDeletedIds
+    saveDeletedInitialIdsToLS(newDeletedIds)
+  } else {
     const customItems = loadCustomItemsFromLS()
     saveCustomItemsToLS(customItems.filter(item => item.id !== id))
   }

--- a/src/firebase/firestore.ts
+++ b/src/firebase/firestore.ts
@@ -24,6 +24,7 @@ export interface ChecklistData {
   order: string[]
   checkedItems: Record<string, boolean>
   customLabels: Record<string, string>
+  deletedInitialIds?: string[]
 }
 
 // ユーザーのチェックリスト設定を取得


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- 削除した初期項目が再読み込み・Firestore同期後に復元されてしまう問題を修正
- 初期項目とカスタム項目で異なっていた削除確認ダイアログを統一
- `ChecklistData` に `deletedInitialIds` フィールドを追加し、削除済み初期項目IDを Firestore / LocalStorage に永続化

## 変更内容

### `src/firebase/firestore.ts`
- `ChecklistData` 型に `deletedInitialIds?: string[]` を追加

### `src/components/GenericChecklist.vue`
- `deletedInitialIds` ref と LocalStorage ヘルパー (`loadDeletedInitialIdsFromLS` / `saveDeletedInitialIdsToLS`) を追加
- `getAllItems()` で削除済み初期項目を除外するよう修正
- `applyFirestoreData()` で `deletedInitialIds` を適用してから項目リストを構築するよう修正
- `buildChecklistData()` に `deletedInitialIds` を含めるよう修正
- `onMounted()` で `loadDeletedInitialIdsFromLS()` を最初に呼ぶよう修正
- `deleteItem()` で初期項目削除時は `deletedInitialIds` に追加するよう修正
- 削除確認ダイアログを「この項目を削除しますか？」に統一

## Test plan

- [ ] 初期項目を削除後、ページをリロードしても復元されないことを確認
- [ ] 複数デバイスで同期した際も削除済み初期項目が表示されないことを確認
- [ ] カスタム項目の削除が引き続き正常に動作することを確認
- [ ] 削除確認ダイアログのメッセージが初期項目・カスタム項目で同一であることを確認

https://claude.ai/code/session_01EP4Zxfn7fE5UpvqPEnYC1T
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EP4Zxfn7fE5UpvqPEnYC1T)_