### PR TITLE
ユーザーごとに別のリストを管理できるように修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -112,8 +112,10 @@ const handleDeleteChecklist = (id: string) => {
 
   const index = checklists.value.findIndex(c => c.id === id)
   checklists.value.splice(index, 1)
-  localStorage.removeItem(`${id}-custom-items`)
-  localStorage.removeItem(`${id}-order`)
+  const uid = user.value?.uid ?? 'guest'
+  localStorage.removeItem(`${uid}-${id}-custom-items`)
+  localStorage.removeItem(`${uid}-${id}-order`)
+  localStorage.removeItem(`${uid}-${id}-deleted-initial-ids`)
   if (user.value) deleteChecklistData(user.value.uid, id).catch(console.error)
   if (activeView.value === id) activeView.value = checklists.value[0].id
 }

--- a/src/components/GenericChecklist.vue
+++ b/src/components/GenericChecklist.vue
@@ -65,8 +65,10 @@ let isSavingToFirestore = false
 let lastFirestoreJson = ''
 
 // ---- LocalStorage ヘルパー ----
+const lsPrefix = () => `${props.uid || 'guest'}-${props.checklistId}`
+
 const loadCustomItemsFromLS = (): ChecklistItem[] => {
-  const saved = localStorage.getItem(`${props.checklistId}-custom-items`)
+  const saved = localStorage.getItem(`${lsPrefix()}-custom-items`)
   if (saved) {
     try { return JSON.parse(saved) } catch { return [] }
   }
@@ -74,20 +76,20 @@ const loadCustomItemsFromLS = (): ChecklistItem[] => {
 }
 
 const saveCustomItemsToLS = (items: ChecklistItem[]) => {
-  localStorage.setItem(`${props.checklistId}-custom-items`, JSON.stringify(items))
+  localStorage.setItem(`${lsPrefix()}-custom-items`, JSON.stringify(items))
 }
 
 const deletedInitialIds = ref<string[]>([])
 
 const loadDeletedInitialIdsFromLS = () => {
-  const saved = localStorage.getItem(`${props.checklistId}-deleted-initial-ids`)
+  const saved = localStorage.getItem(`${lsPrefix()}-deleted-initial-ids`)
   if (saved) {
     try { deletedInitialIds.value = JSON.parse(saved) } catch { deletedInitialIds.value = [] }
   }
 }
 
 const saveDeletedInitialIdsToLS = (ids: string[]) => {
-  localStorage.setItem(`${props.checklistId}-deleted-initial-ids`, JSON.stringify(ids))
+  localStorage.setItem(`${lsPrefix()}-deleted-initial-ids`, JSON.stringify(ids))
 }
 
 const getAllItems = (): ChecklistItem[] => {
@@ -98,7 +100,7 @@ const getAllItems = (): ChecklistItem[] => {
 
 const loadItemOrderFromLS = () => {
   const allItems = getAllItems()
-  const savedOrder = localStorage.getItem(`${props.checklistId}-order`)
+  const savedOrder = localStorage.getItem(`${lsPrefix()}-order`)
   if (savedOrder) {
     try {
       const orderIds: string[] = JSON.parse(savedOrder)
@@ -121,13 +123,13 @@ const loadItemOrderFromLS = () => {
 
 const saveItemOrderToLS = () => {
   const orderIds = checklistItems.value.map(i => i.id)
-  localStorage.setItem(`${props.checklistId}-order`, JSON.stringify(orderIds))
+  localStorage.setItem(`${lsPrefix()}-order`, JSON.stringify(orderIds))
 }
 
 const loadCheckedStateFromLS = () => {
   const saved: Record<string, boolean> = {}
   checklistItems.value.forEach(item => {
-    const val = localStorage.getItem(`${props.checklistId}-${item.id}`)
+    const val = localStorage.getItem(`${lsPrefix()}-${item.id}`)
     saved[item.id] = val === 'true'
   })
   checkedItems.value = saved
@@ -136,7 +138,7 @@ const loadCheckedStateFromLS = () => {
 const loadCustomLabelsFromLS = () => {
   const saved: Record<string, string> = {}
   checklistItems.value.forEach(item => {
-    const val = localStorage.getItem(`${props.checklistId}-${item.id}-label`)
+    const val = localStorage.getItem(`${lsPrefix()}-${item.id}-label`)
     if (val) saved[item.id] = val
   })
   customLabels.value = saved
@@ -216,10 +218,10 @@ const applyFirestoreData = (data: ChecklistData) => {
   saveItemOrderToLS()
   saveCustomItemsToLS(data.customItems)
   Object.entries(data.checkedItems).forEach(([id, checked]) => {
-    localStorage.setItem(`${props.checklistId}-${id}`, String(checked))
+    localStorage.setItem(`${lsPrefix()}-${id}`, String(checked))
   })
   Object.entries(data.customLabels).forEach(([id, label]) => {
-    localStorage.setItem(`${props.checklistId}-${id}-label`, label)
+    localStorage.setItem(`${lsPrefix()}-${id}-label`, label)
   })
 }
 
@@ -278,7 +280,7 @@ watch(
   checkedItems,
   (newValue) => {
     Object.entries(newValue).forEach(([id, checked]) => {
-      localStorage.setItem(`${props.checklistId}-${id}`, String(checked))
+      localStorage.setItem(`${lsPrefix()}-${id}`, String(checked))
     })
     scheduleSaveToFirestore()
   },
@@ -323,7 +325,7 @@ const saveEdit = (id: string) => {
   const trimmedText = editingText.value.trim()
   if (trimmedText) {
     customLabels.value = { ...customLabels.value, [id]: trimmedText }
-    localStorage.setItem(`${props.checklistId}-${id}-label`, trimmedText)
+    localStorage.setItem(`${lsPrefix()}-${id}-label`, trimmedText)
 
     const item = checklistItems.value.find(item => item.id === id)
     if (item && item.label === '') {
@@ -374,14 +376,14 @@ const deleteItem = (id: string) => {
     const newCheckedItems = { ...checkedItems.value }
     delete newCheckedItems[id]
     checkedItems.value = newCheckedItems
-    localStorage.removeItem(`${props.checklistId}-${id}`)
+    localStorage.removeItem(`${lsPrefix()}-${id}`)
   }
 
   if (customLabels.value[id]) {
     const newCustomLabels = { ...customLabels.value }
     delete newCustomLabels[id]
     customLabels.value = newCustomLabels
-    localStorage.removeItem(`${props.checklistId}-${id}-label`)
+    localStorage.removeItem(`${lsPrefix()}-${id}-label`)
   }
 
   saveItemOrderToLS()
@@ -519,7 +521,7 @@ const handleReset = () => {
   const resetState: Record<string, boolean> = {}
   checklistItems.value.forEach(item => {
     resetState[item.id] = false
-    localStorage.removeItem(`${props.checklistId}-${item.id}`)
+    localStorage.removeItem(`${lsPrefix()}-${item.id}`)
   })
   checkedItems.value = resetState
   scheduleSaveToFirestore()

--- a/src/composables/useChecklistConfigSync.ts
+++ b/src/composables/useChecklistConfigSync.ts
@@ -33,8 +33,10 @@ export function useChecklistConfigSync(user: Ref<User | null>) {
   let isSavingToFirestore = false
   let lastFirestoreJson = ''
 
+  const lsKey = () => `checklists-config-${user.value?.uid ?? 'guest'}`
+
   const loadFromLocalStorage = () => {
-    const saved = localStorage.getItem('checklists-config')
+    const saved = localStorage.getItem(lsKey())
     if (saved) {
       try {
         const parsed = JSON.parse(saved)
@@ -49,12 +51,12 @@ export function useChecklistConfigSync(user: Ref<User | null>) {
     } else {
       checklists.value = [...defaultChecklists]
       activeView.value = checklists.value[0].id
-      localStorage.setItem('checklists-config', JSON.stringify(checklists.value))
+      localStorage.setItem(lsKey(), JSON.stringify(checklists.value))
     }
   }
 
   const saveToLocalStorage = () => {
-    localStorage.setItem('checklists-config', JSON.stringify(checklists.value))
+    localStorage.setItem(lsKey(), JSON.stringify(checklists.value))
   }
 
   const saveToFirestore = async (uid: string) => {
@@ -96,6 +98,8 @@ export function useChecklistConfigSync(user: Ref<User | null>) {
 
   watch(user, (newUser, oldUser) => {
     if (newUser) {
+      lastFirestoreJson = ''
+      loadFromLocalStorage()
       startFirestoreSync(newUser.uid)
     } else if (oldUser && !newUser) {
       stopFirestoreSync()


### PR DESCRIPTION
## Summary

- LocalStorageのキーをUID単位でスコープ化し、同一デバイスで複数ユーザーが使用してもデータが混在しないように修正
- チェックリスト設定のLocalStorageキー: `checklists-config` → `checklists-config-{uid}`
- チェックリストデータのLocalStorageキー: `{checklistId}-*` → `{uid}-{checklistId}-*`
- ユーザーの切り替え時（ログイン・ログアウト）に、新しいユーザーのLocalStorageから正しくデータを読み込むよう修正

## 変更ファイル

- `src/composables/useChecklistConfigSync.ts`: `lsKey()` 関数でUIDをキーに含める。ユーザー切り替え時にLocalStorageを再ロード
- `src/components/GenericChecklist.vue`: `lsPrefix()` 関数でUID＋チェックリストIDをキーに含める。全LocalStorage操作を更新
- `src/App.vue`: チェックリスト削除時のLocalStorage削除処理をUID単位に統一

## Test plan

- [ ] ユーザーAでログインしてチェックリストを編集 → ログアウト → ユーザーBでログインしてAのデータが見えないことを確認
- [ ] 同一ユーザーでログアウト後に再ログインしてデータが保持されていることを確認
- [ ] チェックリストの追加・削除・並び替えが正常に動作することを確認

https://claude.ai/code/session_01Vp26o9qmGSJTNH3HAyuhua

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vp26o9qmGSJTNH3HAyuhua)_