### PR TITLE
チェックリスト作成後に編集モードへ自動遷移する

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, onBeforeUnmount, nextTick } from 'vue'
 import NavigationBar, { type NavItem } from './components/NavigationBar.vue'
 import GenericChecklist from './components/GenericChecklist.vue'
 import LoginView from './components/LoginView.vue'
@@ -88,7 +88,7 @@ const handleResetOrDelete = () => {
   else handleReset()
 }
 
-const handleAddChecklist = () => {
+const handleAddChecklist = async () => {
   const name = prompt('新しいチェックリストの名前を入力してください：')
   if (!name?.trim()) return
   const newId = `checklist-${Date.now()}`
@@ -99,6 +99,9 @@ const handleAddChecklist = () => {
   }
   checklists.value.push(newChecklist)
   activeView.value = newId
+  await nextTick()
+  isEditMode.value = true
+  checklistRefs.value[newId]?.enableEditMode()
 }
 
 const handleDeleteChecklist = (id: string) => {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- 新しいチェックリストを作成した直後に編集モードへ自動遷移するよう変更
- `handleAddChecklist` を `async` 関数にし、`nextTick` 後に `isEditMode` を `true` にセット
- 対象の `GenericChecklist` コンポーネントの `enableEditMode()` を呼び出すことで、ユーザーがすぐにアイテム追加・編集を開始できるようにした

## Test plan

- [ ] 新しいチェックリストを作成する（ナビバーの「+」ボタンから名前を入力）
- [ ] 作成後、新しいチェックリストが表示され、編集モードが有効になっていることを確認
- [ ] 既存のチェックリストの編集モード切り替えが引き続き正常に動作することを確認

https://claude.ai/code/session_011KZ7Kg3JDTTKEnbsoDUnHg
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011KZ7Kg3JDTTKEnbsoDUnHg)_