### PR TITLE
チェックリスト削除後に編集モードを終了する

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -121,6 +121,7 @@ const handleDeleteChecklist = (id: string) => {
   localStorage.removeItem(`${uid}-${id}-deleted-initial-ids`)
   if (user.value) deleteChecklistData(user.value.uid, id).catch(console.error)
   if (activeView.value === id) activeView.value = checklists.value[0].id
+  isEditMode.value = false
 }
 
 const handleUpdateChecklistName = (id: string, newName: string) => {


### PR DESCRIPTION
## 変更内容

チェックリストを削除した後、編集モードが `true` のままになっていた問題を修正しました。

`handleDeleteChecklist` の末尾に `isEditMode.value = false` を追加し、削除完了後に自動的に編集画面を抜けるようにしました。

https://claude.ai/code/session_01CAQQhqkdocKXYW4ifJMwEC

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAQQhqkdocKXYW4ifJMwEC)_