### PR TITLE
fix: チェックリスト項目の削除後にリロードで復元される問題を修正

### DIFF
--- a/src/components/GenericChecklist.vue
+++ b/src/components/GenericChecklist.vue
@@ -135,9 +135,12 @@ const serializeForCompare = (data: ChecklistData): string => {
 
 // 現在の状態を ChecklistData にまとめる
 const buildChecklistData = (): ChecklistData => {
+  const deletedStr = localStorage.getItem(`${lsPrefix()}-deleted-initial-ids`)
+  const deletedInitialIds: string[] = deletedStr ? JSON.parse(deletedStr) : []
   return {
     customItems: [...checklistItems.value],
     checkedItems: { ...checkedItems.value },
+    ...(deletedInitialIds.length > 0 ? { deletedInitialIds } : {}),
   }
 }
 
@@ -209,6 +212,9 @@ const applyFirestoreData = (data: ChecklistData) => {
   Object.entries(data.checkedItems).forEach(([id, checked]) => {
     localStorage.setItem(`${lsPrefix()}-${id}`, String(checked))
   })
+  if (legacy.deletedInitialIds && legacy.deletedInitialIds.length > 0) {
+    localStorage.setItem(`${lsPrefix()}-deleted-initial-ids`, JSON.stringify(legacy.deletedInitialIds))
+  }
 }
 
 // Firestoreの購読を開始
@@ -373,11 +379,22 @@ const addNewItem = async () => {
 
 // アイテムを削除
 const deleteItem = (id: string) => {
-  if (!confirm('この項目を削除しますか？')) return
+  const isInitial = props.initialItems.some(item => item.id === id)
+  const message = isInitial ? '初期項目を削除しますか？' : 'この項目を削除しますか？'
+  if (!confirm(message)) return
 
   checklistItems.value = checklistItems.value.filter(item => item.id !== id)
   const customItems = loadCustomItemsFromLS()
   saveCustomItemsToLS(customItems.filter(item => item.id !== id))
+
+  if (isInitial) {
+    const deletedStr = localStorage.getItem(`${lsPrefix()}-deleted-initial-ids`)
+    const deletedIds: string[] = deletedStr ? JSON.parse(deletedStr) : []
+    if (!deletedIds.includes(id)) {
+      deletedIds.push(id)
+      localStorage.setItem(`${lsPrefix()}-deleted-initial-ids`, JSON.stringify(deletedIds))
+    }
+  }
 
   const newCheckedItems = { ...checkedItems.value }
   delete newCheckedItems[id]

--- a/src/firebase/firestore.ts
+++ b/src/firebase/firestore.ts
@@ -22,6 +22,7 @@ export interface ChecklistConfig {
 export interface ChecklistData {
   customItems: ChecklistItem[]
   checkedItems: Record<string, boolean>
+  deletedInitialIds?: string[]
 }
 
 // ユーザーのチェックリスト設定をリアルタイム購読（config には ID のみ保持）


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- 初期アイテムを削除しても、ページリロードや Firestore スナップショット受信時に復元されてしまうバグを修正
- 削除時に `deleted-initial-ids` をローカルストレージへ保存し、`buildChecklistData` で Firestore にも永続化するよう対応
- Firestore から受信した `deletedInitialIds` をローカルストレージへキャッシュし、別デバイスからの削除にも対応
- 初期項目削除時の確認ダイアログのメッセージを「初期項目を削除しますか？」に変更（テスト期待値に合わせる）

## Root Cause

`deleteItem` で初期アイテムを削除した際、削除済み ID を `deleted-initial-ids` に保存していなかったため:
1. ページリロード時の `onMounted` が `props.initialItems` を再スキャンし、削除済みアイテムを `missing` として再追加
2. Firestore スナップショット受信時の `applyFirestoreData` が `customItems` に含まれない初期アイテムを再追加

## Test plan

- [ ] 初期アイテムを削除 → ページリロード後も消えていることを確認
- [ ] カスタムアイテムを削除 → ページリロード後も消えていることを確認
- [ ] ログイン状態で削除 → 別デバイスでも削除が反映されることを確認
- [ ] 削除確認ダイアログで「初期項目を削除しますか？」と表示されることを確認

https://claude.ai/code/session_01KAqHcv1mEhB9LdLqUTvuh2
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KAqHcv1mEhB9LdLqUTvuh2)_