### PR TITLE
起動時の背景色を白に変更

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -203,14 +203,14 @@ const handleUpdateChecklistName = (id: string, newName: string) => {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: white;
 }
 
 .loading-spinner {
   width: 48px;
   height: 48px;
-  border: 4px solid rgba(255, 255, 255, 0.3);
-  border-top-color: white;
+  border: 4px solid rgba(102, 126, 234, 0.2);
+  border-top-color: #667eea;
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -17,15 +17,10 @@
 
 body {
   margin: 0;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: white;
   min-height: 100dvh;
 }
 
-@media (max-width: 600px) {
-  body {
-    background: white;
-  }
-}
 
 #app {
   width: 100%;


### PR DESCRIPTION
## Summary

- ページ読み込み前に紫のグラデーション背景が一瞬見えていた問題を修正
- `body` の背景色をグラデーションから白に変更
- ローディング画面（`.loading-screen`）の背景色も白に変更
- ローディングスピナーの色を白→ブランドカラー（`#667eea`）に調整
- モバイル向けの `@media (max-width: 600px)` の白背景上書きルールを削除（不要になったため）

## Test plan

- [ ] アプリ起動時に白い背景が表示されること
- [ ] ローディングスピナーが白背景上で正しく表示されること
- [ ] ログイン後の通常画面に影響がないこと

https://claude.ai/code/session_01E7bNrdhkn55tGGRWuA41Lx

---
_Generated by [Claude Code](https://claude.ai/code/session_01E7bNrdhkn55tGGRWuA41Lx)_