### PR TITLE
fix: チェック状態が即座に解除されるレースコンディションを修正

### DIFF
--- a/src/components/GenericChecklist.vue
+++ b/src/components/GenericChecklist.vue
@@ -224,10 +224,13 @@ const startFirestoreSync = () => {
   stopFirestoreSync()
   firestoreUnsubscribe = subscribeChecklistData(props.uid, props.checklistId, (data) => {
     if (isSavingToFirestore) return
+    // 常に hasSyncedFromFirestore をセット（保存ガードを解除するため）
     hasSyncedFromFirestore = true
     if (data) {
       const json = serializeForCompare(data)
       if (json === lastFirestoreJson) return
+      // 未保存のローカル変更がある場合は Firestore の古いデータで上書きしない
+      if (saveTimer !== null) return
       lastFirestoreJson = json
       applyFirestoreData(data)
       // label フィールドがない旧フォーマットのドキュメントにラベルを書き込む（移行処理）


### PR DESCRIPTION
$(cat <<'EOF'
## 問題

チェックを入れると即座に解除されることがある。

## 原因

`scheduleSaveToFirestore` には 500ms のデバウンスがある。このウィンドウ中に Firestore からスナップショットが届くと、ローカルの未保存チェック変更が古いデータで上書きされていた。

具体的なシナリオ:
1. チェックを入れる → ローカル `checkedItems` が更新される
2. 500ms の保存タイマーが起動
3. **タイマー終了前に** Firestore から旧スナップショットが届く
4. `isSavingToFirestore = false` かつ `json ≠ lastFirestoreJson` のため `applyFirestoreData` が呼ばれる
5. チェック状態が古い値（未チェック）に戻る

## 修正

`saveTimer !== null`（ローカル保存タイマー起動中）のとき、Firestore から届いたデータを適用しないようにした。

- `hasSyncedFromFirestore` は常にセットし、保存処理のガードは維持する
- 保存完了後は Firestore が確認済みの状態を送り返すため、整合性は保たれる

## Test plan

- [ ] チェックを入れても即座に解除されないことを確認
- [ ] 保存完了後も正しくチェック状態が維持されることを確認
- [ ] 複数アイテムのチェック操作が正常に動作することを確認

https://claude.ai/code/session_01ShgboPERjJNivk37ts92hx
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ShgboPERjJNivk37ts92hx)_