### PR TITLE
fix: リストのタイトルが消える問題を修正

### DIFF
--- a/src/firebase/firestore.ts
+++ b/src/firebase/firestore.ts
@@ -78,7 +78,7 @@ export async function saveChecklistData(
   data: ChecklistData,
 ): Promise<void> {
   const ref = doc(db, 'users', uid, 'checklists', checklistId)
-  await setDoc(ref, data)
+  await setDoc(ref, data, { merge: true })
 }
 
 export async function saveChecklistLabel(


### PR DESCRIPTION
$(cat <<'EOF'
## 問題

チェックリストのデータ（チェック状態、項目の追加・編集・削除）を保存するたびに、リストのタイトルが消えることがあった。

## 原因

`saveChecklistData` が `setDoc(ref, data)` を呼ぶ際に `{ merge: true }` を指定していなかったため、Firestore ドキュメント全体を上書きしていた。

- `saveChecklistLabel` は `{ merge: true }` でタイトルを保存 ✅
- `saveChecklistData` は merge なしでデータを保存 → **タイトルフィールドが削除される** ❌

## 修正

`saveChecklistData` に `{ merge: true }` を追加し、既存の `label` フィールドを保持するようにした。

```diff
- await setDoc(ref, data)
+ await setDoc(ref, data, { merge: true })
```

https://claude.ai/code/session_01BadjLFRavQEHFKUJSj8bPK
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BadjLFRavQEHFKUJSj8bPK)_