### PR TITLE
デバイス間同期がローカル編集後に停止する問題を修正

### DIFF
--- a/src/hooks/useChecklist.ts
+++ b/src/hooks/useChecklist.ts
@@ -65,6 +65,7 @@ export function useChecklist({
     if (!hasSyncedRef.current) return
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current)
     saveTimerRef.current = setTimeout(async () => {
+      saveTimerRef.current = null
       if (!uid) return
       const data = await buildChecklistData()
       const json = serializeForCompare(data)


### PR DESCRIPTION
## 問題

データのデバイス間同期が正しく行われないことがある。具体的には、あるデバイスで一度でもローカル編集（チェック操作・項目追加など）を行うと、それ以降そのデバイスはアプリをリロードするまで他デバイスからの更新を一切受信しなくなっていました。

## 原因

`useChecklist.ts` の `scheduleSaveToFirestore` では、Firestore への保存を 500ms デバウンスするタイマーのハンドルを `saveTimerRef.current` に保持しています。しかし、タイマー発火後に `saveTimerRef.current` を `null` に戻していませんでした。

一方、Firestore のスナップショットハンドラには「保存待ちのローカル編集がある間はリモート更新を適用しない」というガードがあります：

```ts
if (saveTimerRef.current !== null) return
```

タイマーハンドルが残り続けるため、最初のローカル編集以降、このガードがすべてのリモートスナップショットを破棄し続けていました。

## 修正

デバウンスタイマーの発火時に `saveTimerRef.current = null` をセットし、保存完了後はリモート更新が再び適用されるようにしました。

## 検証

- `npm run type-check` がエラーなく通ることを確認

https://claude.ai/code/session_01BMqoswSPzTbK66gKg1XgDd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMqoswSPzTbK66gKg1XgDd)_